### PR TITLE
update app title bar more frequent

### DIFF
--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -181,7 +181,7 @@
             </AppBarButton>
         </CommandBar>
 
-        <RichEditBox x:Name="Text1" Drop="Text1_Drop" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" TextWrapping="{x:Bind q:Converter.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" IsSpellCheckEnabled="{x:Bind QSetting.SpellCheck, Mode=OneWay}" Style="{StaticResource RichEditBox}" FontSize="{x:Bind QSetting.DefaultFontSize, Mode=OneWay}"/>
+        <RichEditBox x:Name="Text1" Drop="Text1_Drop" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" TextWrapping="{x:Bind q:Converter.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" IsSpellCheckEnabled="{x:Bind QSetting.SpellCheck, Mode=OneWay}" Style="{StaticResource RichEditBox}"/>
 
         <ContentDialog x:Name="Settings" Windows10version1809:CornerRadius="4" Background="{ThemeResource SystemControlAcrylicElementBrush}" BorderBrush="{ThemeResource SystemControlForegroundBaseLowBrush}"
            Opened="Settings_Opened">

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -555,7 +555,7 @@ namespace Quick_Pad_Free_Edition
 
                 Text1.Document.SetText(TextSetOptions.None, await FileIO.ReadTextAsync(CurrentWorkingFile));
             }
-            //Cleaf undo/redo history
+            //Clear undo/redo history
             Text1.TextDocument.ClearUndoRedoHistory();
             //Get a plain text regardless of the format
             Text1.Document.GetText(TextGetOptions.None, out string ext);
@@ -648,8 +648,8 @@ namespace Quick_Pad_Free_Edition
                     QSetting.NewFileAutoNumber++;
                 }
             }
-            //Get a plain text regardless of the format
-            Text1.Document.GetText(TextGetOptions.None, out string ext);
+            //Get a formatted text to notice a change in format
+            Text1.Document.GetText(TextGetOptions.FormatRtf, out string ext);
             initialLoadedContent = ext;
         }
         #endregion
@@ -719,7 +719,10 @@ namespace Quick_Pad_Free_Edition
             {
                 //File have been saved! And no change has been made. Reset right away
                 Text1.Document.SetText(TextSetOptions.None, string.Empty);
-
+            }
+            if (QSetting.DefaultFileType == ".rtf")
+            {
+                UpdateText1FontSize(QSetting.DefaultFontSize);
             }
             //reset the value of the friendly file name
             CurrentWorkingFile = null;
@@ -760,8 +763,8 @@ namespace Quick_Pad_Free_Edition
                     CurrentFilename = CurrentWorkingFile.DisplayName;
                     //Clear undo and redo, so the last undo will be the loaded text
                     Text1.TextDocument.ClearUndoRedoHistory();
-                    //Get a text length
-                    Text1.Document.GetText(TextGetOptions.None, out string res);
+                    //Get a formatted text to notice a change in format, this one is for guideline
+                    Text1.Document.GetText(TextGetOptions.FormatRtf, out string res);
                     initialLoadedContent = res;
                 }
                 catch (Exception)
@@ -1132,8 +1135,8 @@ namespace Quick_Pad_Free_Edition
             }
             else
             {
-                //Get a plain text regardless of the format
-                Text1.Document.GetText(TextGetOptions.None, out string ext);
+                //Get a formatted text to notice a change in format
+                Text1.Document.GetText(TextGetOptions.FormatRtf, out string ext);
                 //Compare and check if it changed
                 Changed = !Equals(initialLoadedContent, ext);
             }

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -444,6 +444,7 @@ namespace Quick_Pad_Free_Edition
                 {
                     Set(ref _changed, value);
                     NotifyPropertyChanged(nameof(CurrentFilename));
+                    UpdateAppTitlebar();
                 }
             }
         }
@@ -583,6 +584,7 @@ namespace Quick_Pad_Free_Edition
                     CurrentWorkingFile.FileType.ToLower() == ".rtf" ? TextGetOptions.FormatRtf : TextGetOptions.None, 
                     out var value);
                 await PathIO.WriteTextAsync(CurrentWorkingFile.Path, value);
+                Changed = false;
             }
 
             catch (Exception)
@@ -608,11 +610,14 @@ namespace Quick_Pad_Free_Edition
                 savePicker.FileTypeChoices.Add("All Files", new List<string>() { "." });
 
                 // Default file name if the user does not type one in or select a file to replace
-                savePicker.SuggestedFileName = $"{_file_name}{QSetting.NewFileAutoNumber}";
+                string name = string.IsNullOrEmpty(_file_name) ? textResource.GetString("NewDocument") : _file_name;
+                savePicker.SuggestedFileName = $"{name}{QSetting.NewFileAutoNumber}";
 
                 Windows.Storage.StorageFile file = await savePicker.PickSaveFileAsync();
                 if (file != null)
                 {
+                    //Change has been saved
+                    Changed = false;
                     //Set the current working file
                     CurrentWorkingFile = file;
                     //update title bar
@@ -649,7 +654,6 @@ namespace Quick_Pad_Free_Edition
             //Get a plain text regardless of the format
             Text1.Document.GetText(TextGetOptions.None, out string ext);
             initialLoadedContent = ext;
-            Changed = false;
         }
         #endregion
 

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -77,6 +77,7 @@ namespace Quick_Pad_Free_Edition
             QSetting.afterThemeChanged += UpdateUIAccordingToNewTheme;
             UpdateUIAccordingToNewTheme(QSetting.Theme);
             QSetting.afterFontSizeChanged += UpdateText1FontSize;
+            UpdateText1FontSize(QSetting.DefaultFontSize);
             QSetting.afterAutoSaveChanged += UpdateAutoSave;
             //
             CreateItems();
@@ -126,13 +127,9 @@ namespace Quick_Pad_Free_Edition
                     case DialogResult.Yes:
                         await SaveWork();
                         deferral.Complete();
-                        //Save font size setting
-                        QSetting.DefaultFontSize = Convert.ToInt32(Text1.Document.Selection.FormattedText.CharacterFormat.Size);
                         break;
                     case DialogResult.No:
                         deferral.Complete();
-                        //Save font size setting
-                        QSetting.DefaultFontSize = Convert.ToInt32(Text1.Document.Selection.FormattedText.CharacterFormat.Size);
                         break;
                     case DialogResult.Cancel:
                         e.Handled = true;


### PR DESCRIPTION
### First commit
It will make in-app document name and app title bar on task bar update when there are change made in document and after saved a file

This should address the issue #13 

And it will also fix the issue when saving file and it only suggest number instead of "New Document[number]"

### Second commit
This should address issue #17 

I believe this is a misunderstanding. It is not the default font size but instead a formatted font size inside the saved file. This commit should remove the part where it saving default font size when quitting the app and properly format the RichEditBox on srartup to the default font size

### Third commit
This should address issue #18 

What I did is making app compare to string of formatRTF instead of plain non-format string