### PR TITLE
Translation and fixes v2

### DIFF
--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -300,38 +300,38 @@
                         <SymbolIcon Symbol="Underline"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Strikethrough" Click="Strikethrough_Click" x:Uid="ClassicFormatST">
+                <MenuFlyoutItem Text="Strikethrough" Click="Strikethrough_Click" x:Uid="ClassicFormatST" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowStrikethroughOption), Mode=OneWay}">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Bullets" Click="BulletList_Click" x:Uid="ClassicFormatBullets">
+                <MenuFlyoutItem Text="Bullets" Click="BulletList_Click" x:Uid="ClassicFormatBullets" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowBullets), Mode=OneWay}">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Bullets"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Align leff" Click="Left_Click" x:Uid="ClassicFormatALeft">
+                <MenuFlyoutItem Text="Align leff" Click="Left_Click" x:Uid="ClassicFormatALeft" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignLeft), Mode=OneWay}">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="AlignLeft"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Align center" Click="Center_Click" x:Uid="ClassicFormatACenter">
+                <MenuFlyoutItem Text="Align center" Click="Center_Click" x:Uid="ClassicFormatACenter" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignCenter), Mode=OneWay}">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="AlignCenter"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Align right" Click="Right_Click" x:Uid="ClassicFormatARight">
+                <MenuFlyoutItem Text="Align right" Click="Right_Click" x:Uid="ClassicFormatARight" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignRight), Mode=OneWay}">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="AlignRight"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Align justify" Click="Justify_Click" x:Uid="ClassicFormatAJustify">
+                <MenuFlyoutItem Text="Align justify" Click="Justify_Click" x:Uid="ClassicFormatAJustify" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignJustify), Mode=OneWay}">
                     <MenuFlyoutItem.Icon>
                         <BitmapIcon UriSource="/Assets/justify align.png"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutSeparator/>
+                <MenuFlyoutSeparator Visibility="{x:Bind q:Converter.HideIfNoAlignButtonShow(QSetting.ShowAlignLeft, QSetting.ShowAlignCenter, QSetting.ShowAlignRight, QSetting.ShowAlignJustify), Mode=OneWay}"/>
                 <MenuFlyoutItem Text="Size up" Click="SizeUp_Click" x:Uid="ClassicFormatUp">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="FontIncrease"/>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -101,7 +101,7 @@
             </AppBarButton>
             <AppBarButton x:Name="BulletList" x:Uid="BulletList"  Label="Bullets"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowBullets), Mode=OneWay}" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch">
                 <ToolTipService.ToolTip>
-                    <TextBlock Text="Toggle Bullets" x:Uid="BuTooltip"/>
+                    <TextBlock Text="Toggle Bullets" x:Uid="BulletListTooltip"/>
                 </ToolTipService.ToolTip>
             </AppBarButton>
             <AppBarSeparator/>
@@ -144,7 +144,7 @@
         <CommandBar x:Name="CommandBar2" DefaultLabelPosition="Collapsed" Canvas.ZIndex="75" IsOpen="False" HorizontalAlignment="Right" Grid.Row="1" VerticalAlignment="Top" Height="40" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}">
             <CommandBar.SecondaryCommands>
                 <AppBarButton x:Name="CmdFocusMode" x:Uid="CmdFocusMode" Click="{x:Bind TurnOnFocusMode}" Icon="Caption" Label="Focus Mode" Width="Auto"/>
-                <AppBarButton x:Name="CmdClassicMode" Click="{x:Bind TurnOnClassicMode}" Label="Classic Mode" Width="Auto">
+                <AppBarButton x:Name="CmdClassicMode" Click="{x:Bind TurnOnClassicMode}" Label="Classic Mode" x:Uid="CmdClassicMode" Width="Auto">
                     <AppBarButton.Icon>
                         <FontIcon Glyph="&#xE8C5;" />
                     </AppBarButton.Icon>
@@ -160,9 +160,9 @@
                         <TextBlock Text="Settings" x:Uid="CmdSettingsTooltip"/>
                     </ToolTipService.ToolTip>
                 </AppBarButton>
-                <AppBarButton Icon="Cancel" Label="Exit" Width="Auto" Click="CmdExit_Click">
+                <AppBarButton Icon="Cancel" Label="Exit" Width="Auto" Click="CmdExit_Click" x:Uid="CmdExit">
                     <ToolTipService.ToolTip>
-                        <TextBlock Text="Exit the app"/>
+                        <TextBlock Text="Exit the app" x:Uid="CmdExitTooltip"/>
                     </ToolTipService.ToolTip>
                 </AppBarButton>
             </CommandBar.SecondaryCommands>
@@ -200,8 +200,8 @@
         </CommandBar>
 
         <winui:MenuBar x:Name="CommandBarClassic" Canvas.ZIndex="75" HorizontalAlignment="Left" Grid.Row="1" VerticalAlignment="Top" Height="40" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Visibility="{x:Bind q:Converter.BoolToVisibility(ClassicModeSwitch), Mode=OneWay}">
-            <winui:MenuBarItem Title="File">
-                <MenuFlyoutItem Text="New" Click="CmdNew_Click">
+            <winui:MenuBarItem Title="File" x:Uid="ClassicFile">
+                <MenuFlyoutItem Text="New" Click="CmdNew_Click" x:Uid="ClassicFileNew">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE7C3;"/>
                     </MenuFlyoutItem.Icon>
@@ -211,7 +211,7 @@
                            Key="N" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Open" Click="CmdOpen_Click">
+                <MenuFlyoutItem Text="Open" Click="CmdOpen_Click" x:Uid="ClassicFileOpen">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xF12B;"/>
                     </MenuFlyoutItem.Icon>
@@ -221,7 +221,7 @@
                            Key="O" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Save" Click="CmdSave_Click">
+                <MenuFlyoutItem Text="Save" Click="CmdSave_Click" x:Uid="ClassicFileSave">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Save"/>
                     </MenuFlyoutItem.Icon>
@@ -231,7 +231,7 @@
                            Key="S" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Save as..." Click="CmdSaveAs_Click">
+                <MenuFlyoutItem Text="Save as..." Click="CmdSaveAs_Click" x:Uid="ClassicFileSaveAs">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Save"/>
                     </MenuFlyoutItem.Icon>
@@ -242,132 +242,132 @@
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Share" Click="CmdShare_Click">
+                <MenuFlyoutItem Text="Share" Click="CmdShare_Click" x:Uid="ClassicFileShare">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Share"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Exit" Click="CmdExit_Click">
+                <MenuFlyoutItem Text="Exit" Click="CmdExit_Click" x:Uid="ClassicFileExit">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE8BB;"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </winui:MenuBarItem>
-            <winui:MenuBarItem Title="Edit">
-                <MenuFlyoutItem Text="Undo" Click="CmdUndo_Click">
+            <winui:MenuBarItem Title="Edit" x:Uid="ClassicEdit">
+                <MenuFlyoutItem Text="Undo" Click="CmdUndo_Click" x:Uid="ClassicEditUndo">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Undo"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Redo" Click="CmdRedo_Click">
+                <MenuFlyoutItem Text="Redo" Click="CmdRedo_Click" x:Uid="ClassicEditRedo">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Redo"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Cut" Click="Cut_Click">
+                <MenuFlyoutItem Text="Cut" Click="Cut_Click" x:Uid="ClassicEditCut">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Cut"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Copy" Click="Copy_Click">
+                <MenuFlyoutItem Text="Copy" Click="Copy_Click" x:Uid="ClassicEditCopy">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Copy"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Paste" Click="Paste_Click">
+                <MenuFlyoutItem Text="Paste" Click="Paste_Click" x:Uid="ClassicEditPaste">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Paste"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </winui:MenuBarItem>
-            <winui:MenuBarItem Title="Format">
-                <ToggleMenuFlyoutItem Text="Word Wrap" IsChecked="{x:Bind QSetting.WordWrap, Mode=TwoWay}"/>
+            <winui:MenuBarItem Title="Format" x:Uid="ClassicFormat">
+                <ToggleMenuFlyoutItem Text="Word Wrap" IsChecked="{x:Bind QSetting.WordWrap, Mode=TwoWay}" x:Uid="WordWrap"/>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Bold" Click="Bold_Click">
+                <MenuFlyoutItem Text="Bold" Click="Bold_Click" x:Uid="ClassicFormatBold">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Bold"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Italic" Click="Italic_Click">
+                <MenuFlyoutItem Text="Italic" Click="Italic_Click" x:Uid="ClassicFormatItalic">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Italic"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Underline" Click="Underline_Click">
+                <MenuFlyoutItem Text="Underline" Click="Underline_Click" x:Uid="ClassicFormatUnderline">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Underline"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Strikethrough" Click="Strikethrough_Click">
+                <MenuFlyoutItem Text="Strikethrough" Click="Strikethrough_Click" x:Uid="ClassicFormatST">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Bullets" Click="BulletList_Click">
+                <MenuFlyoutItem Text="Bullets" Click="BulletList_Click" x:Uid="ClassicFormatBullets">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Bullets"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Align leff" Click="Left_Click">
+                <MenuFlyoutItem Text="Align leff" Click="Left_Click" x:Uid="ClassicFormatALeft">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="AlignLeft"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Align center" Click="Center_Click">
+                <MenuFlyoutItem Text="Align center" Click="Center_Click" x:Uid="ClassicFormatACenter">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="AlignCenter"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Align right" Click="Right_Click">
+                <MenuFlyoutItem Text="Align right" Click="Right_Click" x:Uid="ClassicFormatARight">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="AlignRight"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Align justify" Click="Justify_Click">
+                <MenuFlyoutItem Text="Align justify" Click="Justify_Click" x:Uid="ClassicFormatAJustify">
                     <MenuFlyoutItem.Icon>
                         <BitmapIcon UriSource="/Assets/justify align.png"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Size up" Click="SizeUp_Click">
+                <MenuFlyoutItem Text="Size up" Click="SizeUp_Click" x:Uid="ClassicFormatUp">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="FontIncrease"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Size down" Click="SizeDown_Click">
+                <MenuFlyoutItem Text="Size down" Click="SizeDown_Click" x:Uid="ClassicFormatDown">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="FontDecrease"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </winui:MenuBarItem>
-            <winui:MenuBarItem Title="View">
-                <ToggleMenuFlyoutItem Text="Back to default mode" IsChecked="{x:Bind ClassicModeSwitch, Mode=TwoWay}">
+            <winui:MenuBarItem Title="View" x:Uid="ClassicView">
+                <ToggleMenuFlyoutItem Text="Back to default mode" IsChecked="{x:Bind ClassicModeSwitch, Mode=TwoWay}" x:Uid="ClassicViewBack">
                     <ToggleMenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Back"/>
                     </ToggleMenuFlyoutItem.Icon>
                 </ToggleMenuFlyoutItem>
-                <ToggleMenuFlyoutItem Text="Focus Mode" IsChecked="{x:Bind FocusModeSwitch, Mode=TwoWay}">
+                <ToggleMenuFlyoutItem Text="Focus Mode" IsChecked="{x:Bind FocusModeSwitch, Mode=TwoWay}" x:Uid="ClassicViewFocus">
                     <ToggleMenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Caption"/>
                     </ToggleMenuFlyoutItem.Icon>
                 </ToggleMenuFlyoutItem>
-                <ToggleMenuFlyoutItem Text="Overlay mode" IsChecked="{x:Bind CompactOverlaySwitch, Mode=TwoWay}">
+                <ToggleMenuFlyoutItem Text="Overlay mode" IsChecked="{x:Bind CompactOverlaySwitch, Mode=TwoWay}" x:Uid="ClassicViewOverlay">
                     <ToggleMenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE158;" />
                     </ToggleMenuFlyoutItem.Icon>
                 </ToggleMenuFlyoutItem>
             </winui:MenuBarItem>
-            <winui:MenuBarItem Title="Help">
-                <MenuFlyoutItem Text="Settings" Click="CmdSettings_Click">
+            <winui:MenuBarItem Title="Help" x:Uid="ClassicHelp">
+                <MenuFlyoutItem Text="Settings" Click="CmdSettings_Click" x:Uid="CmdSettingsTooltip">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Setting"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Rate and Review" Click="CmdReview_Click">
+                <MenuFlyoutItem Text="Rate and Review" Click="CmdReview_Click" x:Uid="ClassicHelpRR">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="SolidStar"/>
                     </MenuFlyoutItem.Icon>

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -859,8 +859,17 @@ namespace QuickPad
             await SaveWork();
         }
 
-        public void CmdExit_Click(object sender, RoutedEventArgs e)
+        public async void CmdExit_Click(object sender, RoutedEventArgs e)
         {
+            await WantToSave.ShowAsync();
+            switch (WantToSave.DialogResult)
+            {
+                case DialogResult.Yes:
+                    await SaveWork();
+                    break;
+                case DialogResult.Cancel:
+                    return;
+            }
             App.Current.Exit();
         }
 

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
@@ -514,6 +514,142 @@
           <source>Word Wrap</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Retour automatique à la ligne</target>
         </trans-unit>
+        <trans-unit id="ClassicEdit.Title" translate="yes" xml:space="preserve">
+          <source>Edit</source>
+          <target state="new">Edit</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditCopy.Text" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="new">Copy</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditCut.Text" translate="yes" xml:space="preserve">
+          <source>Cut</source>
+          <target state="new">Cut</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditPaste.Text" translate="yes" xml:space="preserve">
+          <source>Paste</source>
+          <target state="new">Paste</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditRedo.Text" translate="yes" xml:space="preserve">
+          <source>Redo</source>
+          <target state="new">Redo</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditUndo.Text" translate="yes" xml:space="preserve">
+          <source>Undo</source>
+          <target state="new">Undo</target>
+        </trans-unit>
+        <trans-unit id="ClassicFile.Title" translate="yes" xml:space="preserve">
+          <source>File</source>
+          <target state="new">File</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileExit.Text" translate="yes" xml:space="preserve">
+          <source>Exit</source>
+          <target state="new">Exit</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileNew.Text" translate="yes" xml:space="preserve">
+          <source>New</source>
+          <target state="new">New</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileOpen.Text" translate="yes" xml:space="preserve">
+          <source>Open</source>
+          <target state="new">Open</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileSave.Text" translate="yes" xml:space="preserve">
+          <source>Save</source>
+          <target state="new">Save</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileSaveAs.Text" translate="yes" xml:space="preserve">
+          <source>Save as...</source>
+          <target state="new">Save as...</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileShare.Text" translate="yes" xml:space="preserve">
+          <source>Share</source>
+          <target state="new">Share</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormat.Title" translate="yes" xml:space="preserve">
+          <source>Format</source>
+          <target state="new">Format</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatACenter.Text" translate="yes" xml:space="preserve">
+          <source>Align center</source>
+          <target state="new">Align center</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatAJustify.Text" translate="yes" xml:space="preserve">
+          <source>Align justify</source>
+          <target state="new">Align justify</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatALeft.Text" translate="yes" xml:space="preserve">
+          <source>Align left</source>
+          <target state="new">Align left</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatARight.Text" translate="yes" xml:space="preserve">
+          <source>Align right</source>
+          <target state="new">Align right</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatBold.Text" translate="yes" xml:space="preserve">
+          <source>Bold</source>
+          <target state="new">Bold</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatBullets.Text" translate="yes" xml:space="preserve">
+          <source>Bullets</source>
+          <target state="new">Bullets</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatDown.Text" translate="yes" xml:space="preserve">
+          <source>Font Down</source>
+          <target state="new">Font Down</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatItalic.Text" translate="yes" xml:space="preserve">
+          <source>Italic</source>
+          <target state="new">Italic</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatST.Text" translate="yes" xml:space="preserve">
+          <source>Strikethrough</source>
+          <target state="new">Strikethrough</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatUnderline.Text" translate="yes" xml:space="preserve">
+          <source>Underline</source>
+          <target state="new">Underline</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatUp.Text" translate="yes" xml:space="preserve">
+          <source>Font Up</source>
+          <target state="new">Font Up</target>
+        </trans-unit>
+        <trans-unit id="ClassicHelp.Title" translate="yes" xml:space="preserve">
+          <source>Help</source>
+          <target state="new">Help</target>
+        </trans-unit>
+        <trans-unit id="ClassicHelpRR.Text" translate="yes" xml:space="preserve">
+          <source>Rate and Review</source>
+          <target state="new">Rate and Review</target>
+        </trans-unit>
+        <trans-unit id="ClassicView.Title" translate="yes" xml:space="preserve">
+          <source>View</source>
+          <target state="new">View</target>
+        </trans-unit>
+        <trans-unit id="ClassicViewBack.Text" translate="yes" xml:space="preserve">
+          <source>Back to Default</source>
+          <target state="new">Back to Default</target>
+        </trans-unit>
+        <trans-unit id="ClassicViewFocus.Text" translate="yes" xml:space="preserve">
+          <source>Focus</source>
+          <target state="new">Focus</target>
+        </trans-unit>
+        <trans-unit id="ClassicViewOverlay.Text" translate="yes" xml:space="preserve">
+          <source>On Top</source>
+          <target state="new">On Top</target>
+        </trans-unit>
+        <trans-unit id="CmdClassicMode.Label" translate="yes" xml:space="preserve">
+          <source>Classic Mode</source>
+          <target state="new">Classic Mode</target>
+        </trans-unit>
+        <trans-unit id="CmdExit.Label" translate="yes" xml:space="preserve">
+          <source>Exit</source>
+          <target state="new">Exit</target>
+        </trans-unit>
+        <trans-unit id="CmdExitTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Exit the app</source>
+          <target state="new">Exit the app</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -514,6 +514,142 @@
           <source>Classic</source>
           <target state="translated">คลาสสิค</target>
         </trans-unit>
+        <trans-unit id="ClassicEdit.Title" translate="yes" xml:space="preserve">
+          <source>Edit</source>
+          <target state="translated" state-qualifier="tm-suggestion">แก้ไข</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditCopy.Text" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="translated" state-qualifier="tm-suggestion">คัดลอก</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditCut.Text" translate="yes" xml:space="preserve">
+          <source>Cut</source>
+          <target state="translated" state-qualifier="tm-suggestion">ตัด</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditPaste.Text" translate="yes" xml:space="preserve">
+          <source>Paste</source>
+          <target state="translated" state-qualifier="tm-suggestion">วาง</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditRedo.Text" translate="yes" xml:space="preserve">
+          <source>Redo</source>
+          <target state="translated" state-qualifier="tm-suggestion">ทำซ้ำ</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditUndo.Text" translate="yes" xml:space="preserve">
+          <source>Undo</source>
+          <target state="translated" state-qualifier="tm-suggestion">เลิกทำ</target>
+        </trans-unit>
+        <trans-unit id="ClassicFile.Title" translate="yes" xml:space="preserve">
+          <source>File</source>
+          <target state="translated" state-qualifier="tm-suggestion">แฟ้ม</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileExit.Text" translate="yes" xml:space="preserve">
+          <source>Exit</source>
+          <target state="translated" state-qualifier="tm-suggestion">ออก</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileNew.Text" translate="yes" xml:space="preserve">
+          <source>New</source>
+          <target state="translated" state-qualifier="tm-suggestion">ใหม่</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileOpen.Text" translate="yes" xml:space="preserve">
+          <source>Open</source>
+          <target state="translated" state-qualifier="tm-suggestion">เปิด</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileSave.Text" translate="yes" xml:space="preserve">
+          <source>Save</source>
+          <target state="translated" state-qualifier="tm-suggestion">บันทึก</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileSaveAs.Text" translate="yes" xml:space="preserve">
+          <source>Save as...</source>
+          <target state="translated">บันทึกเป็น</target>
+        </trans-unit>
+        <trans-unit id="ClassicFileShare.Text" translate="yes" xml:space="preserve">
+          <source>Share</source>
+          <target state="translated" state-qualifier="tm-suggestion">แชร์</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormat.Title" translate="yes" xml:space="preserve">
+          <source>Format</source>
+          <target state="translated">รูปแบบ</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatACenter.Text" translate="yes" xml:space="preserve">
+          <source>Align center</source>
+          <target state="translated" state-qualifier="tm-suggestion">จัดกึ่งกลาง</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatAJustify.Text" translate="yes" xml:space="preserve">
+          <source>Align justify</source>
+          <target state="translated">จัดเต็มแนว</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatALeft.Text" translate="yes" xml:space="preserve">
+          <source>Align left</source>
+          <target state="translated">จัดชิดซ้าย</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatARight.Text" translate="yes" xml:space="preserve">
+          <source>Align right</source>
+          <target state="translated" state-qualifier="tm-suggestion">จัดชิดขวา</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatBold.Text" translate="yes" xml:space="preserve">
+          <source>Bold</source>
+          <target state="translated" state-qualifier="tm-suggestion">ตัวหนา</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatBullets.Text" translate="yes" xml:space="preserve">
+          <source>Bullets</source>
+          <target state="translated" state-qualifier="tm-suggestion">สัญลักษณ์แสดงหัวข้อย่อย</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatDown.Text" translate="yes" xml:space="preserve">
+          <source>Font Down</source>
+          <target state="translated">ย่อขนาดตัวอักษร</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatItalic.Text" translate="yes" xml:space="preserve">
+          <source>Italic</source>
+          <target state="translated" state-qualifier="tm-suggestion">ตัวเอียง</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatST.Text" translate="yes" xml:space="preserve">
+          <source>Strikethrough</source>
+          <target state="translated" state-qualifier="tm-suggestion">ขีดทับ</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatUnderline.Text" translate="yes" xml:space="preserve">
+          <source>Underline</source>
+          <target state="translated" state-qualifier="tm-suggestion">ขีดเส้นใต้</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatUp.Text" translate="yes" xml:space="preserve">
+          <source>Font Up</source>
+          <target state="translated">ขยายขนาดตัวอักษร</target>
+        </trans-unit>
+        <trans-unit id="ClassicHelp.Title" translate="yes" xml:space="preserve">
+          <source>Help</source>
+          <target state="translated">อื่นๆ</target>
+        </trans-unit>
+        <trans-unit id="ClassicHelpRR.Text" translate="yes" xml:space="preserve">
+          <source>Rate and Review</source>
+          <target state="translated" state-qualifier="tm-suggestion">ให้คะแนนและวิจารณ์</target>
+        </trans-unit>
+        <trans-unit id="ClassicViewBack.Text" translate="yes" xml:space="preserve">
+          <source>Back to Default</source>
+          <target state="translated">กลับไปมุมมองเดิม</target>
+        </trans-unit>
+        <trans-unit id="ClassicViewFocus.Text" translate="yes" xml:space="preserve">
+          <source>Focus</source>
+          <target state="translated">เน้นพิมพ์</target>
+        </trans-unit>
+        <trans-unit id="ClassicViewOverlay.Text" translate="yes" xml:space="preserve">
+          <source>On Top</source>
+          <target state="translated">ทับแอปอื่น</target>
+        </trans-unit>
+        <trans-unit id="ClassicView.Title" translate="yes" xml:space="preserve">
+          <source>View</source>
+          <target state="translated">มุมมอง</target>
+        </trans-unit>
+        <trans-unit id="CmdClassicMode.Label" translate="yes" xml:space="preserve">
+          <source>Classic Mode</source>
+          <target state="translated">เมนูคลาสสิค</target>
+        </trans-unit>
+        <trans-unit id="CmdExit.Label" translate="yes" xml:space="preserve">
+          <source>Exit</source>
+          <target state="translated">ออก</target>
+        </trans-unit>
+        <trans-unit id="CmdExitTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Exit the app</source>
+          <target state="translated">ปิดแอปไปทำอย่างอื่น</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -498,4 +498,106 @@
   <data name="WordWrap.Text" xml:space="preserve">
     <value>Word Wrap</value>
   </data>
+  <data name="ClassicEdit.Title" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="ClassicEditCopy.Text" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="ClassicEditCut.Text" xml:space="preserve">
+    <value>Cut</value>
+  </data>
+  <data name="ClassicEditPaste.Text" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="ClassicEditRedo.Text" xml:space="preserve">
+    <value>Redo</value>
+  </data>
+  <data name="ClassicEditUndo.Text" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="ClassicFile.Title" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="ClassicFileExit.Text" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="ClassicFileNew.Text" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="ClassicFileOpen.Text" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="ClassicFileSave.Text" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="ClassicFileSaveAs.Text" xml:space="preserve">
+    <value>Save as...</value>
+  </data>
+  <data name="ClassicFileShare.Text" xml:space="preserve">
+    <value>Share</value>
+  </data>
+  <data name="ClassicFormat.Title" xml:space="preserve">
+    <value>Format</value>
+  </data>
+  <data name="ClassicFormatACenter.Text" xml:space="preserve">
+    <value>Align center</value>
+  </data>
+  <data name="ClassicFormatAJustify.Text" xml:space="preserve">
+    <value>Align justify</value>
+  </data>
+  <data name="ClassicFormatALeft.Text" xml:space="preserve">
+    <value>Align left</value>
+  </data>
+  <data name="ClassicFormatARight.Text" xml:space="preserve">
+    <value>Align right</value>
+  </data>
+  <data name="ClassicFormatBold.Text" xml:space="preserve">
+    <value>Bold</value>
+  </data>
+  <data name="ClassicFormatBullets.Text" xml:space="preserve">
+    <value>Bullets</value>
+  </data>
+  <data name="ClassicFormatDown.Text" xml:space="preserve">
+    <value>Font Down</value>
+  </data>
+  <data name="ClassicFormatItalic.Text" xml:space="preserve">
+    <value>Italic</value>
+  </data>
+  <data name="ClassicFormatST.Text" xml:space="preserve">
+    <value>Strikethrough</value>
+  </data>
+  <data name="ClassicFormatUnderline.Text" xml:space="preserve">
+    <value>Underline</value>
+  </data>
+  <data name="ClassicFormatUp.Text" xml:space="preserve">
+    <value>Font Up</value>
+  </data>
+  <data name="ClassicHelp.Title" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="ClassicHelpRR.Text" xml:space="preserve">
+    <value>Rate and Review</value>
+  </data>
+  <data name="ClassicView.Title" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="ClassicViewBack.Text" xml:space="preserve">
+    <value>Back to Default</value>
+  </data>
+  <data name="ClassicViewFocus.Text" xml:space="preserve">
+    <value>Focus</value>
+  </data>
+  <data name="ClassicViewOverlay.Text" xml:space="preserve">
+    <value>On Top</value>
+  </data>
+  <data name="CmdClassicMode.Label" xml:space="preserve">
+    <value>Classic Mode</value>
+  </data>
+  <data name="CmdExit.Label" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="CmdExitTooltip.Text" xml:space="preserve">
+    <value>Exit the app</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/fr-CA/Resources.resw
+++ b/Quick Pad/Strings/fr-CA/Resources.resw
@@ -12,4 +12,385 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AppTheme.Text" xml:space="preserve">
+    <value>Thème de l'application</value>
+  </data>
+  <data name="AutoSaveSwitch.Text" xml:space="preserve">
+    <value>Sauvegarde automatique</value>
+  </data>
+  <data name="BlackPlaceholder" xml:space="preserve">
+    <value>Noir</value>
+  </data>
+  <data name="Bold.Label" xml:space="preserve">
+    <value>Gras</value>
+  </data>
+  <data name="BoldTooltip.Text" xml:space="preserve">
+    <value>Gras (Ctrl+B)</value>
+  </data>
+  <data name="BulletList.Label" xml:space="preserve">
+    <value>Puces</value>
+  </data>
+  <data name="BulletListTooltip.Text" xml:space="preserve">
+    <value>Basculer les puces</value>
+  </data>
+  <data name="Center.Label" xml:space="preserve">
+    <value>Centre</value>
+  </data>
+  <data name="CenterTooltip.Text" xml:space="preserve">
+    <value>Aligner au centre (Ctrl+E)</value>
+  </data>
+  <data name="CmdFocusMode.Label" xml:space="preserve">
+    <value>Mode focus</value>
+  </data>
+  <data name="CmdNew.Label" xml:space="preserve">
+    <value>Nouveau</value>
+  </data>
+  <data name="CmdNewTooltip.Text" xml:space="preserve">
+    <value>Nouveau</value>
+  </data>
+  <data name="CmdOpen.Label" xml:space="preserve">
+    <value>Ouvrir</value>
+  </data>
+  <data name="CmdOpenTooltip.Text" xml:space="preserve">
+    <value>Ouvrir (Ctrl+O)</value>
+  </data>
+  <data name="CmdRedo.Label" xml:space="preserve">
+    <value>Répéter</value>
+  </data>
+  <data name="CmdRedoTooltip.Text" xml:space="preserve">
+    <value>Répéter (Ctrl+Y)</value>
+  </data>
+  <data name="CmdReview.Label" xml:space="preserve">
+    <value>Révision</value>
+  </data>
+  <data name="CmdSave.Label" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="CmdSaveTooltip.Text" xml:space="preserve">
+    <value>Enregistrer (Ctrl+S)</value>
+  </data>
+  <data name="CmdSettings.Label" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="CmdSettingsTooltip.Text" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="CmdShare.Label" xml:space="preserve">
+    <value>Partager</value>
+  </data>
+  <data name="CmdShareTooltip.Text" xml:space="preserve">
+    <value>Partager le fichier que vous êtes en train de travailler.</value>
+  </data>
+  <data name="CmdUndo.Label" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="CmdUndoTooltip.Text" xml:space="preserve">
+    <value>Annuler (Ctrl+Z)</value>
+  </data>
+  <data name="CompactOverlay.Content" xml:space="preserve">
+    <value>En haut</value>
+  </data>
+  <data name="Contribute.Content" xml:space="preserve">
+    <value>Contribuer au développeur</value>
+  </data>
+  <data name="Copy.Label" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="CopyTooltip.Text" xml:space="preserve">
+    <value>Copier (Ctrl+C)</value>
+  </data>
+  <data name="Cut.Label" xml:space="preserve">
+    <value>Couper</value>
+  </data>
+  <data name="CutTooltip.Text" xml:space="preserve">
+    <value>Couper (Ctrl+X)</value>
+  </data>
+  <data name="Dark.Content" xml:space="preserve">
+    <value>Sombre</value>
+  </data>
+  <data name="DefaultFont.Text" xml:space="preserve">
+    <value>Police par défaut</value>
+  </data>
+  <data name="DefaultFontColor.Text" xml:space="preserve">
+    <value>Couleur de police par défaut</value>
+  </data>
+  <data name="DefaultFontColorCombobox.PlaceholderText" xml:space="preserve">
+    <value>Noir</value>
+  </data>
+  <data name="DefaultFontSize.Text" xml:space="preserve">
+    <value>Taille de police par défaut</value>
+  </data>
+  <data name="DevelopedBy.Text" xml:space="preserve">
+    <value>Développé par Yair Aichenbaum</value>
+  </data>
+  <data name="ErrorDialogContent" xml:space="preserve">
+    <value>Désolé, Quick Pad ne peut pas ouvrir le fichier.</value>
+  </data>
+  <data name="ErrorDialogOk" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="ErrorDialogTitle" xml:space="preserve">
+    <value>Échec de l'ouverture du fichier</value>
+  </data>
+  <data name="ExitFocusMode.Text" xml:space="preserve">
+    <value>Fermer le mode focus</value>
+  </data>
+  <data name="FontColorBlack" xml:space="preserve">
+    <value>Noir</value>
+  </data>
+  <data name="FontColorBlue" xml:space="preserve">
+    <value>Bleu</value>
+  </data>
+  <data name="FontColorGreen" xml:space="preserve">
+    <value>Vert</value>
+  </data>
+  <data name="FontColorOrange" xml:space="preserve">
+    <value>Orange</value>
+  </data>
+  <data name="FontColorPink" xml:space="preserve">
+    <value>Rose</value>
+  </data>
+  <data name="FontColorWhite" xml:space="preserve">
+    <value>Blanc</value>
+  </data>
+  <data name="FontColorYellow" xml:space="preserve">
+    <value>Jaune</value>
+  </data>
+  <data name="GeneralAutoSave.Text" xml:space="preserve">
+    <value>Sauvegarde automatique</value>
+  </data>
+  <data name="GeneralDefaultType.Text" xml:space="preserve">
+    <value>Type de fichier par défaut</value>
+  </data>
+  <data name="GeneralLaunchMode.Text" xml:space="preserve">
+    <value>Mode lancement</value>
+  </data>
+  <data name="GeneralLaunchModeCombobox.PlaceholderText" xml:space="preserve">
+    <value>Par défaut</value>
+  </data>
+  <data name="GeneralToggleSwitch.OffContent" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+  <data name="GeneralToggleSwitch.OnContent" xml:space="preserve">
+    <value>Activé</value>
+  </data>
+  <data name="IconDesignBy.Text" xml:space="preserve">
+    <value>Design de l'icône par James Arney</value>
+  </data>
+  <data name="Italic.Label" xml:space="preserve">
+    <value>Italique</value>
+  </data>
+  <data name="ItalicTooltip.Text" xml:space="preserve">
+    <value>Italique (Ctrl+I)</value>
+  </data>
+  <data name="Justify.Label" xml:space="preserve">
+    <value>Justifié</value>
+  </data>
+  <data name="JustifyTooltip.Text" xml:space="preserve">
+    <value>Justifier le texte (Ctrl+J)</value>
+  </data>
+  <data name="LaunchModeClassic.Content" xml:space="preserve">
+    <value>Classique</value>
+  </data>
+  <data name="LaunchInClassicMode" xml:space="preserve">
+    <value>Classique</value>
+  </data>
+  <data name="LaunchInClassicModeDesc" xml:space="preserve">
+    <value>Ouvrir l'application en mode classique</value>
+  </data>
+  <data name="LaunchInFocusMode" xml:space="preserve">
+    <value>Focus</value>
+  </data>
+  <data name="LaunchInFocusModeDesc" xml:space="preserve">
+    <value>Ouvrir l'application en mode focus</value>
+  </data>
+  <data name="LaunchInOnTopMode" xml:space="preserve">
+    <value>Superposé</value>
+  </data>
+  <data name="LaunchInOnTopModeDesc" xml:space="preserve">
+    <value>Ouvrir l'application en mode superposé</value>
+  </data>
+  <data name="LaunchModeDefault.Content" xml:space="preserve">
+    <value>Par défaut</value>
+  </data>
+  <data name="LaunchModeFocus.Content" xml:space="preserve">
+    <value>Focus</value>
+  </data>
+  <data name="LaunchModeOnTop.Content" xml:space="preserve">
+    <value>En haut</value>
+  </data>
+  <data name="Left.Label" xml:space="preserve">
+    <value>À gauche</value>
+  </data>
+  <data name="LeftTooltip.Text" xml:space="preserve">
+    <value>Aligner à gauche (Ctrl+L)</value>
+  </data>
+  <data name="Light.Content" xml:space="preserve">
+    <value>Clair</value>
+  </data>
+  <data name="NewDocument" xml:space="preserve">
+    <value>Nouveau document</value>
+  </data>
+  <data name="NewUserFeedbackContent" xml:space="preserve">
+    <value>S'il vous plais, veuillez considérer de laisser un commentaire pour Quick Pad dans le magasin</value>
+  </data>
+  <data name="NewUserFeedbackNo" xml:space="preserve">
+    <value>Non</value>
+  </data>
+  <data name="NewUserFeedbackTitle" xml:space="preserve">
+    <value>Est-ce que vous appréciez Quick Pad?</value>
+  </data>
+  <data name="NewUserFeedbackYes" xml:space="preserve">
+    <value>Oui</value>
+  </data>
+  <data name="NothingToShare" xml:space="preserve">
+    <value>Rien à partager, insérez quelque chose pour le partager.</value>
+  </data>
+  <data name="Paste.Label" xml:space="preserve">
+    <value>Coller</value>
+  </data>
+  <data name="PasteTooltip.Text" xml:space="preserve">
+    <value>Coller (Ctrl+V)</value>
+  </data>
+  <data name="RateAndReview.Content" xml:space="preserve">
+    <value>Évaluer et commenter</value>
+  </data>
+  <data name="Right.Label" xml:space="preserve">
+    <value>Droite</value>
+  </data>
+  <data name="RightTooltip.Text" xml:space="preserve">
+    <value>Aligner à droite (Ctrl+R)</value>
+  </data>
+  <data name="SaveDialog.Text" xml:space="preserve">
+    <value>Voulez-vous enregistrer vos modifications?</value>
+  </data>
+  <data name="SaveDialogCancel.Content" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="SaveDialogNo.Content" xml:space="preserve">
+    <value>Non</value>
+  </data>
+  <data name="SaveDialogYes.Content" xml:space="preserve">
+    <value>Oui</value>
+  </data>
+  <data name="SendFeedback.Content" xml:space="preserve">
+    <value>Envoyer des commentaires</value>
+  </data>
+  <data name="SettingsPivot.Title" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="SettingsTab1.Header" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="SettingsTab2.Header" xml:space="preserve">
+    <value>Thème</value>
+  </data>
+  <data name="SettingsTab3.Header" xml:space="preserve">
+    <value>Police</value>
+  </data>
+  <data name="SettingsTab4.Header" xml:space="preserve">
+    <value>Barre d'outils</value>
+  </data>
+  <data name="SettingsTab5.Header" xml:space="preserve">
+    <value>À propos</value>
+  </data>
+  <data name="ShowAlignCenter.OffContent" xml:space="preserve">
+    <value>Cacher l'algnement au centre</value>
+  </data>
+  <data name="ShowAlignCenter.OnContent" xml:space="preserve">
+    <value>Montrer l'alignement au centre</value>
+  </data>
+  <data name="ShowAlignJustify.OffContent" xml:space="preserve">
+    <value>Cacher l'alignement justifié</value>
+  </data>
+  <data name="ShowAlignJustify.OnContent" xml:space="preserve">
+    <value>Montrer l'alignement justifié</value>
+  </data>
+  <data name="ShowAlignLeft.OffContent" xml:space="preserve">
+    <value>Cacher l'alignement à gauche</value>
+  </data>
+  <data name="ShowAlignLeft.OnContent" xml:space="preserve">
+    <value>Montrer l'alignement à gauche</value>
+  </data>
+  <data name="ShowAlignRight.OffContent" xml:space="preserve">
+    <value>Cacher l'alignement à droite</value>
+  </data>
+  <data name="ShowAlignRight.OnContent" xml:space="preserve">
+    <value>Montrer l'alignement à droite</value>
+  </data>
+  <data name="ShowBullets.OffContent" xml:space="preserve">
+    <value>Cacher la liste de puce</value>
+  </data>
+  <data name="ShowBullets.OnContent" xml:space="preserve">
+    <value>Montrer la liste de puce</value>
+  </data>
+  <data name="ShowStrikethrough.OffContent" xml:space="preserve">
+    <value>Cacher l'option barrée</value>
+  </data>
+  <data name="ShowStrikethrough.OnContent" xml:space="preserve">
+    <value>Montrer l'option barrée</value>
+  </data>
+  <data name="SizeDown.Label" xml:space="preserve">
+    <value>Taille plus bas</value>
+  </data>
+  <data name="SizeDownTooltip.Text" xml:space="preserve">
+    <value>Taille plus bas</value>
+  </data>
+  <data name="SizeUp.Label" xml:space="preserve">
+    <value>Taille plus haut</value>
+  </data>
+  <data name="SizeUpTooltip.Text" xml:space="preserve">
+    <value>Taille plus haut </value>
+  </data>
+  <data name="SpellCheck.Text" xml:space="preserve">
+    <value>Vérification de l'orthographe</value>
+  </data>
+  <data name="Strikethrough.Label" xml:space="preserve">
+    <value>Barré</value>
+  </data>
+  <data name="StrikethroughTooltip.Text" xml:space="preserve">
+    <value>Barré</value>
+  </data>
+  <data name="SystemDefault.Content" xml:space="preserve">
+    <value>Paramètres du système par défaut</value>
+  </data>
+  <data name="TextColorBlack.Text" xml:space="preserve">
+    <value>Noir</value>
+  </data>
+  <data name="TextColorBlue.Text" xml:space="preserve">
+    <value>Bleu</value>
+  </data>
+  <data name="TextColorGreen.Text" xml:space="preserve">
+    <value>Vert</value>
+  </data>
+  <data name="TextColorOrange.Text" xml:space="preserve">
+    <value>Orange</value>
+  </data>
+  <data name="TextColorPink.Text" xml:space="preserve">
+    <value>Rose</value>
+  </data>
+  <data name="TextColorTooltip.Text" xml:space="preserve">
+    <value>Couleur de police</value>
+  </data>
+  <data name="TextColorWhite.Text" xml:space="preserve">
+    <value>Blanc</value>
+  </data>
+  <data name="TextColorYellow.Text" xml:space="preserve">
+    <value>Jaune</value>
+  </data>
+  <data name="Underline.Label" xml:space="preserve">
+    <value>Souligné</value>
+  </data>
+  <data name="UnderlineTooltip.Text" xml:space="preserve">
+    <value>Souligner (Ctrl+U)</value>
+  </data>
+  <data name="VersionFormat" xml:space="preserve">
+    <value>Version: {0} ({1}, {2}{3})</value>
+  </data>
+  <data name="WhitePlaceholder" xml:space="preserve">
+    <value>Blanc</value>
+  </data>
+  <data name="WordWrap.Text" xml:space="preserve">
+    <value>Retour automatique à la ligne</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -393,4 +393,106 @@
   <data name="LaunchModeClassic.Content" xml:space="preserve">
     <value>คลาสสิค</value>
   </data>
+  <data name="ClassicEdit.Title" xml:space="preserve">
+    <value>แก้ไข</value>
+  </data>
+  <data name="ClassicEditCopy.Text" xml:space="preserve">
+    <value>คัดลอก</value>
+  </data>
+  <data name="ClassicEditCut.Text" xml:space="preserve">
+    <value>ตัด</value>
+  </data>
+  <data name="ClassicEditPaste.Text" xml:space="preserve">
+    <value>วาง</value>
+  </data>
+  <data name="ClassicEditRedo.Text" xml:space="preserve">
+    <value>ทำซ้ำ</value>
+  </data>
+  <data name="ClassicEditUndo.Text" xml:space="preserve">
+    <value>เลิกทำ</value>
+  </data>
+  <data name="ClassicFile.Title" xml:space="preserve">
+    <value>แฟ้ม</value>
+  </data>
+  <data name="ClassicFileExit.Text" xml:space="preserve">
+    <value>ออก</value>
+  </data>
+  <data name="ClassicFileNew.Text" xml:space="preserve">
+    <value>ใหม่</value>
+  </data>
+  <data name="ClassicFileOpen.Text" xml:space="preserve">
+    <value>เปิด</value>
+  </data>
+  <data name="ClassicFileSave.Text" xml:space="preserve">
+    <value>บันทึก</value>
+  </data>
+  <data name="ClassicFileSaveAs.Text" xml:space="preserve">
+    <value>บันทึกเป็น</value>
+  </data>
+  <data name="ClassicFileShare.Text" xml:space="preserve">
+    <value>แชร์</value>
+  </data>
+  <data name="ClassicFormat.Title" xml:space="preserve">
+    <value>รูปแบบ</value>
+  </data>
+  <data name="ClassicFormatACenter.Text" xml:space="preserve">
+    <value>จัดกึ่งกลาง</value>
+  </data>
+  <data name="ClassicFormatAJustify.Text" xml:space="preserve">
+    <value>จัดเต็มแนว</value>
+  </data>
+  <data name="ClassicFormatALeft.Text" xml:space="preserve">
+    <value>จัดชิดซ้าย</value>
+  </data>
+  <data name="ClassicFormatARight.Text" xml:space="preserve">
+    <value>จัดชิดขวา</value>
+  </data>
+  <data name="ClassicFormatBold.Text" xml:space="preserve">
+    <value>ตัวหนา</value>
+  </data>
+  <data name="ClassicFormatBullets.Text" xml:space="preserve">
+    <value>สัญลักษณ์แสดงหัวข้อย่อย</value>
+  </data>
+  <data name="ClassicFormatDown.Text" xml:space="preserve">
+    <value>ย่อขนาดตัวอักษร</value>
+  </data>
+  <data name="ClassicFormatItalic.Text" xml:space="preserve">
+    <value>ตัวเอียง</value>
+  </data>
+  <data name="ClassicFormatST.Text" xml:space="preserve">
+    <value>ขีดทับ</value>
+  </data>
+  <data name="ClassicFormatUnderline.Text" xml:space="preserve">
+    <value>ขีดเส้นใต้</value>
+  </data>
+  <data name="ClassicFormatUp.Text" xml:space="preserve">
+    <value>ขยายขนาดตัวอักษร</value>
+  </data>
+  <data name="ClassicHelp.Title" xml:space="preserve">
+    <value>อื่นๆ</value>
+  </data>
+  <data name="ClassicHelpRR.Text" xml:space="preserve">
+    <value>ให้คะแนนและวิจารณ์</value>
+  </data>
+  <data name="ClassicViewBack.Text" xml:space="preserve">
+    <value>กลับไปมุมมองเดิม</value>
+  </data>
+  <data name="ClassicViewFocus.Text" xml:space="preserve">
+    <value>เน้นพิมพ์</value>
+  </data>
+  <data name="ClassicViewOverlay.Text" xml:space="preserve">
+    <value>ทับแอปอื่น</value>
+  </data>
+  <data name="ClassicView.Title" xml:space="preserve">
+    <value>มุมมอง</value>
+  </data>
+  <data name="CmdClassicMode.Label" xml:space="preserve">
+    <value>เมนูคลาสสิค</value>
+  </data>
+  <data name="CmdExit.Label" xml:space="preserve">
+    <value>ออก</value>
+  </data>
+  <data name="CmdExitTooltip.Text" xml:space="preserve">
+    <value>ปิดแอปไปทำอย่างอื่น</value>
+  </data>
 </root>


### PR DESCRIPTION
- Adding translation into Classic menu
- Update Thai translation
- Apply toolbar setting to classic menu
- Ask before exit from app

Additionally
- Fix "Toggle Bullets" x:Uid point to a wrong translation, causing it to stay English only
- Build French-Canadian XLF file, which updated the file fr-CA\Resources.resw