### PR TITLE
Status bar

### DIFF
--- a/Quick Pad/Dialog/FontAndFormat.xaml
+++ b/Quick Pad/Dialog/FontAndFormat.xaml
@@ -27,10 +27,11 @@
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="69"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <!--Fonts search-->
-            <Grid Margin="0,0,10,0">
+            <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
@@ -39,16 +40,14 @@
                 <ListBox MinHeight="150" MaxHeight="250" MinWidth="150" HorizontalAlignment="Stretch" Grid.Row="1" ItemsSource="{x:Bind FilteredFonts, Mode=OneWay}" SelectedItem="{x:Bind SelectedOnFilteredFont, Mode=TwoWay}">
                     <ListBox.ItemTemplate>
                         <DataTemplate x:DataType="x:String">
-                            <StackPanel>
-                                <TextBlock Text="{x:Bind}" FontFamily="{x:Bind Converter={StaticResource FontNameToFontFamily}}"/>
-                                <TextBlock Text="{x:Bind}" Style="{ThemeResource CaptionTextBlockStyle}"/>
-                            </StackPanel>
+                            <TextBlock Text="{x:Bind}" Style="{ThemeResource CaptionTextBlockStyle}"/>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
             </Grid>
 
-            <StackPanel Orientation="Vertical" Grid.Column="1">
+            <!--Size and decorations-->
+            <StackPanel Orientation="Vertical" Grid.Column="1" Margin="5,0">
                 <StackPanel.Resources>
                     <Style TargetType="ToggleButton">
                         <Setter Property="Margin" Value="0,5"/>
@@ -92,30 +91,31 @@
                 </ToggleButton>
             </StackPanel>
 
-            <Grid Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <StackPanel Grid.Column="0" Grid.Row="1" Margin="10,0,0,0">
-                    <TextBlock Text="Color" Padding="0,0,0,4"/>
-                    <winui:ColorPicker Width="Auto" 
-                               Color="{x:Bind SelectedColor, Mode=TwoWay}"
-                               IsColorSliderVisible="False"
-                               IsColorChannelTextInputVisible="False"
-                               IsHexInputVisible="False"
-                               IsAlphaEnabled="False"
-                               IsAlphaSliderVisible="False"
-                               IsAlphaTextInputVisible="False" />
-                </StackPanel>
+            <!--Color-->
+            <StackPanel Grid.Column="2">
+                <TextBlock Text="Color" Margin="0,0,0,4"/>
+                <winui:ColorPicker Width="100" 
+                                       Color="{x:Bind SelectedColor, Mode=TwoWay}"
+                                       IsColorSliderVisible="False"
+                                       IsColorChannelTextInputVisible="False"
+                                       IsHexInputVisible="False"
+                                       IsAlphaEnabled="False"
+                                       IsAlphaSliderVisible="False"
+                                       IsAlphaTextInputVisible="False"
+                                       IsColorPreviewVisible="False"/>
+            </StackPanel>
 
-                <!--Preview-->
-                <TextBox IsHitTestVisible="False"
-                     Grid.Column="1"
-                     Margin="20,10" 
-                     Padding="10"
-                     Text="Preview"/>
-            </Grid>
+            <!--Preview-->
+            <RichEditBox Style="{StaticResource RichEditBox}"
+                             IsHitTestVisible="False"
+                             Grid.Column="0"
+                         Grid.ColumnSpan="3"
+                         Margin="0,10"
+                         Grid.Row="1"
+                             VerticalAlignment="Center"
+                             HorizontalAlignment="Center"
+                             x:Name="PreviewBox"
+                             BorderThickness="0"/>
         </Grid>
     </ScrollViewer>
 </ContentDialog>

--- a/Quick Pad/Dialog/FontAndFormat.xaml
+++ b/Quick Pad/Dialog/FontAndFormat.xaml
@@ -6,96 +6,116 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:w10v1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:winui="using:Microsoft.UI.Xaml.Controls"
     xmlns:q="using:QuickPad"
     mc:Ignorable="d"
     Title="Fonts"
     PrimaryButtonText="Apply"
     SecondaryButtonText="Cancel"
     PrimaryButtonClick="{x:Bind ApplyAllSettings}"
-    SecondaryButtonClick="{x:Bind DropEverything}">
+    SecondaryButtonClick="{x:Bind DropEverything}"
+    Opened="ContentDialog_Opened">
     <ContentDialog.Resources>
         <local:FontFamilySpecificConverter x:Key="FontNameToFontFamily"/>
     </ContentDialog.Resources>
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
-        <!--Fonts search-->
-        <Grid Margin="0,0,10,0">
+    <ScrollViewer>
+        <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <AutoSuggestBox Header="Fonts" BorderThickness="1" Text="{x:Bind FontNameSuggestionInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-            <ListBox MinHeight="150" MinWidth="150" HorizontalAlignment="Stretch" Grid.Row="1" ItemsSource="{x:Bind FilteredFonts, Mode=OneWay}" SelectedItem="{x:Bind SelectedOnFilteredFont, Mode=TwoWay}">
-                <ListBox.ItemTemplate>
-                    <DataTemplate x:DataType="x:String">
-                        <StackPanel>
-                            <TextBlock Text="{x:Bind}" FontFamily="{x:Bind Converter={StaticResource FontNameToFontFamily}}"/>
-                            <TextBlock Text="{x:Bind}" Style="{ThemeResource CaptionTextBlockStyle}"/>
-                        </StackPanel>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="69"/>
+            </Grid.ColumnDefinitions>
+            <!--Fonts search-->
+            <Grid Margin="0,0,10,0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <AutoSuggestBox Header="Fonts" BorderThickness="1" Text="{x:Bind FontNameSuggestionInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <ListBox MinHeight="150" MaxHeight="250" MinWidth="150" HorizontalAlignment="Stretch" Grid.Row="1" ItemsSource="{x:Bind FilteredFonts, Mode=OneWay}" SelectedItem="{x:Bind SelectedOnFilteredFont, Mode=TwoWay}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="x:String">
+                            <StackPanel>
+                                <TextBlock Text="{x:Bind}" FontFamily="{x:Bind Converter={StaticResource FontNameToFontFamily}}"/>
+                                <TextBlock Text="{x:Bind}" Style="{ThemeResource CaptionTextBlockStyle}"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+
+            <StackPanel Orientation="Vertical" Grid.Column="1">
+                <StackPanel.Resources>
+                    <Style TargetType="ToggleButton">
+                        <Setter Property="Margin" Value="0,5"/>
+                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                        <Setter Property="MinHeight" Value="32"/>
+                    </Style>
+                </StackPanel.Resources>
+                <ComboBox SelectedItem="{x:Bind FontSizeSelection, Mode=TwoWay}" Header="Size" w10v1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" MinWidth="69" BorderThickness="1">
+                    <x:Int32>4</x:Int32>
+                    <x:Int32>6</x:Int32>
+                    <x:Int32>8</x:Int32>
+                    <x:Int32>10</x:Int32>
+                    <x:Int32>12</x:Int32>
+                    <x:Int32>14</x:Int32>
+                    <x:Int32>16</x:Int32>
+                    <x:Int32>18</x:Int32>
+                    <x:Int32>20</x:Int32>
+                    <x:Int32>22</x:Int32>
+                    <x:Int32>24</x:Int32>
+                    <x:Int32>26</x:Int32>
+                    <x:Int32>28</x:Int32>
+                    <x:Int32>36</x:Int32>
+                    <x:Int32>48</x:Int32>
+                    <x:Int32>72</x:Int32>
+                </ComboBox>
+
+                <ToggleButton IsChecked="{x:Bind WantBold, Mode=TwoWay}">
+                    <SymbolIcon Symbol="Bold"/>
+                </ToggleButton>
+
+                <ToggleButton IsChecked="{x:Bind WantItalic, Mode=TwoWay}">
+                    <SymbolIcon Symbol="Italic"/>
+                </ToggleButton>
+
+                <ToggleButton IsChecked="{x:Bind WantUnderline, Mode=TwoWay}">
+                    <SymbolIcon Symbol="Underline"/>
+                </ToggleButton>
+
+                <ToggleButton IsChecked="{x:Bind WantStrikethrough, Mode=TwoWay}">
+                    <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
+                </ToggleButton>
+            </StackPanel>
+
+            <Grid Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Grid.Row="1" Margin="10,0,0,0">
+                    <TextBlock Text="Color" Padding="0,0,0,4"/>
+                    <winui:ColorPicker Width="Auto" 
+                               Color="{x:Bind SelectedColor, Mode=TwoWay}"
+                               IsColorSliderVisible="False"
+                               IsColorChannelTextInputVisible="False"
+                               IsHexInputVisible="False"
+                               IsAlphaEnabled="False"
+                               IsAlphaSliderVisible="False"
+                               IsAlphaTextInputVisible="False" />
+                </StackPanel>
+
+                <!--Preview-->
+                <TextBox IsHitTestVisible="False"
+                     Grid.Column="1"
+                     Margin="20,10" 
+                     Padding="10"
+                     Text="Preview"/>
+            </Grid>
         </Grid>
-
-        <StackPanel Orientation="Vertical" Grid.Column="1">
-            <StackPanel.Resources>
-                <Style TargetType="ToggleButton">
-                    <Setter Property="Margin" Value="0,5"/>
-                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                    <Setter Property="MinHeight" Value="32"/>
-                </Style>
-            </StackPanel.Resources>
-            <ComboBox SelectedItem="{x:Bind FontSizeSelection, Mode=TwoWay}" Header="Size" w10v1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" MinWidth="69" BorderThickness="1">
-                <x:Int32>4</x:Int32>
-                <x:Int32>6</x:Int32>
-                <x:Int32>8</x:Int32>
-                <x:Int32>10</x:Int32>
-                <x:Int32>12</x:Int32>
-                <x:Int32>14</x:Int32>
-                <x:Int32>16</x:Int32>
-                <x:Int32>18</x:Int32>
-                <x:Int32>20</x:Int32>
-                <x:Int32>22</x:Int32>
-                <x:Int32>24</x:Int32>
-                <x:Int32>26</x:Int32>
-                <x:Int32>28</x:Int32>
-                <x:Int32>36</x:Int32>
-                <x:Int32>48</x:Int32>
-                <x:Int32>72</x:Int32>
-            </ComboBox>
-
-            <ToggleButton IsChecked="{x:Bind WantBold, Mode=TwoWay}">
-                <SymbolIcon Symbol="Bold"/>
-            </ToggleButton>
-
-            <ToggleButton IsChecked="{x:Bind WantItalic, Mode=TwoWay}">
-                <SymbolIcon Symbol="Italic"/>
-            </ToggleButton>
-
-            <ToggleButton IsChecked="{x:Bind WantUnderline, Mode=TwoWay}">
-                <SymbolIcon Symbol="Underline"/>
-            </ToggleButton>
-
-            <ToggleButton IsChecked="{x:Bind WantStrikethrough, Mode=TwoWay}">
-                <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
-            </ToggleButton>
-        </StackPanel>
-        
-        <!--Preview-->
-        <TextBox IsEnabled="False" 
-                 Grid.Row="1" 
-                 Grid.ColumnSpan="2" 
-                 Margin="20,10" 
-                 Padding="10"
-                 Text="Preview"
-                 TextWrapping="Wrap"/>
-    </Grid>
+    </ScrollViewer>
 </ContentDialog>

--- a/Quick Pad/Dialog/FontAndFormat.xaml
+++ b/Quick Pad/Dialog/FontAndFormat.xaml
@@ -5,9 +5,14 @@
     xmlns:local="using:QuickPad.Dialog"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:w10v1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     xmlns:q="using:QuickPad"
     mc:Ignorable="d"
-    Title="Fonts">
+    Title="Fonts"
+    PrimaryButtonText="Apply"
+    SecondaryButtonText="Cancel"
+    PrimaryButtonClick="{x:Bind ApplyAllSettings}"
+    SecondaryButtonClick="{x:Bind DropEverything}">
     <ContentDialog.Resources>
         <local:FontFamilySpecificConverter x:Key="FontNameToFontFamily"/>
     </ContentDialog.Resources>
@@ -22,32 +27,75 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <!--Fonts search-->
-        <StackPanel Orientation="Vertical">
-            <AutoSuggestBox Text="{x:Bind FontNameSuggestionInput, UpdateSourceTrigger=PropertyChanged}"/>
-            <ListBox MinHeight="150" MinWidth="150" HorizontalAlignment="Stretch">
+        <Grid Margin="0,0,10,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <AutoSuggestBox Header="Fonts" BorderThickness="1" Text="{x:Bind FontNameSuggestionInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            <ListBox MinHeight="150" MinWidth="150" HorizontalAlignment="Stretch" Grid.Row="1" ItemsSource="{x:Bind FilteredFonts, Mode=OneWay}" SelectedItem="{x:Bind SelectedOnFilteredFont, Mode=TwoWay}">
                 <ListBox.ItemTemplate>
                     <DataTemplate x:DataType="x:String">
                         <StackPanel>
-                            <TextBlock Text="{x:Bind}" FontFamily="{Binding ,Converter={StaticResource FontNameToFontFamily}}"/>
+                            <TextBlock Text="{x:Bind}" FontFamily="{x:Bind Converter={StaticResource FontNameToFontFamily}}"/>
                             <TextBlock Text="{x:Bind}" Style="{ThemeResource CaptionTextBlockStyle}"/>
                         </StackPanel>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
-        </StackPanel>
+        </Grid>
 
         <StackPanel Orientation="Vertical" Grid.Column="1">
-            <AutoSuggestBox Text="{x:Bind FontNameSuggestionInput, UpdateSourceTrigger=PropertyChanged}"/>
-            <ListBox MinHeight="150" MinWidth="150" HorizontalAlignment="Stretch">
-                <ListBox.ItemTemplate>
-                    <DataTemplate x:DataType="x:String">
-                        <StackPanel>
-                            <TextBlock Text="{x:Bind}" FontFamily="{Binding ,Converter={StaticResource FontNameToFontFamily}}"/>
-                            <TextBlock Text="{x:Bind}" Style="{ThemeResource CaptionTextBlockStyle}"/>
-                        </StackPanel>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
+            <StackPanel.Resources>
+                <Style TargetType="ToggleButton">
+                    <Setter Property="Margin" Value="0,5"/>
+                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                    <Setter Property="MinHeight" Value="32"/>
+                </Style>
+            </StackPanel.Resources>
+            <ComboBox SelectedItem="{x:Bind FontSizeSelection, Mode=TwoWay}" Header="Size" w10v1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" MinWidth="69" BorderThickness="1">
+                <x:Int32>4</x:Int32>
+                <x:Int32>6</x:Int32>
+                <x:Int32>8</x:Int32>
+                <x:Int32>10</x:Int32>
+                <x:Int32>12</x:Int32>
+                <x:Int32>14</x:Int32>
+                <x:Int32>16</x:Int32>
+                <x:Int32>18</x:Int32>
+                <x:Int32>20</x:Int32>
+                <x:Int32>22</x:Int32>
+                <x:Int32>24</x:Int32>
+                <x:Int32>26</x:Int32>
+                <x:Int32>28</x:Int32>
+                <x:Int32>36</x:Int32>
+                <x:Int32>48</x:Int32>
+                <x:Int32>72</x:Int32>
+            </ComboBox>
+
+            <ToggleButton IsChecked="{x:Bind WantBold, Mode=TwoWay}">
+                <SymbolIcon Symbol="Bold"/>
+            </ToggleButton>
+
+            <ToggleButton IsChecked="{x:Bind WantItalic, Mode=TwoWay}">
+                <SymbolIcon Symbol="Italic"/>
+            </ToggleButton>
+
+            <ToggleButton IsChecked="{x:Bind WantUnderline, Mode=TwoWay}">
+                <SymbolIcon Symbol="Underline"/>
+            </ToggleButton>
+
+            <ToggleButton IsChecked="{x:Bind WantStrikethrough, Mode=TwoWay}">
+                <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
+            </ToggleButton>
         </StackPanel>
+        
+        <!--Preview-->
+        <TextBox IsEnabled="False" 
+                 Grid.Row="1" 
+                 Grid.ColumnSpan="2" 
+                 Margin="20,10" 
+                 Padding="10"
+                 Text="Preview"
+                 TextWrapping="Wrap"/>
     </Grid>
 </ContentDialog>

--- a/Quick Pad/Dialog/FontAndFormat.xaml
+++ b/Quick Pad/Dialog/FontAndFormat.xaml
@@ -9,12 +9,14 @@
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
     xmlns:q="using:QuickPad"
     mc:Ignorable="d"
-    Title="Fonts"
     PrimaryButtonText="Apply"
     SecondaryButtonText="Cancel"
     PrimaryButtonClick="{x:Bind ApplyAllSettings}"
     SecondaryButtonClick="{x:Bind DropEverything}"
     Opened="ContentDialog_Opened">
+    <ContentDialog.Title>
+        <TextBlock Text="Fonts" x:Uid="FAF_Fonts"/>
+    </ContentDialog.Title>
     <ContentDialog.Resources>
         <local:FontFamilySpecificConverter x:Key="FontNameToFontFamily"/>
     </ContentDialog.Resources>
@@ -35,7 +37,11 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <AutoSuggestBox Header="Fonts" BorderThickness="1" Text="{x:Bind FontNameSuggestionInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <AutoSuggestBox BorderThickness="1" Text="{x:Bind FontNameSuggestionInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    <AutoSuggestBox.Header>
+                        <TextBlock Text="Fonts" x:Uid="FAF_Fonts"/>
+                    </AutoSuggestBox.Header>
+                </AutoSuggestBox>
                 <ListBox MinHeight="150" MaxHeight="250" MinWidth="150" HorizontalAlignment="Stretch" Grid.Row="1" ItemsSource="{x:Bind FilteredFonts, Mode=OneWay}" SelectedItem="{x:Bind SelectedOnFilteredFont, Mode=TwoWay}">
                     <ListBox.ItemTemplate>
                         <DataTemplate x:DataType="x:String">
@@ -54,7 +60,10 @@
                         <Setter Property="MinHeight" Value="28"/>
                     </Style>
                 </StackPanel.Resources>
-                <ComboBox SelectedItem="{x:Bind FontSizeSelection, Mode=TwoWay}" Header="Size" w10v1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" BorderThickness="1">
+                <ComboBox SelectedItem="{x:Bind FontSizeSelection, Mode=TwoWay}" w10v1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" BorderThickness="1">
+                    <ComboBox.Header>
+                        <TextBlock Text="Size" x:Uid="FAF_Size"/>
+                    </ComboBox.Header>
                     <x:Int32>4</x:Int32>
                     <x:Int32>6</x:Int32>
                     <x:Int32>8</x:Int32>
@@ -95,7 +104,7 @@
                     <Button.Flyout>
                         <Flyout>
                             <StackPanel Grid.Column="2">
-                                <TextBlock Text="Color" Margin="0,0,0,4"/>
+                                <TextBlock Text="Color" Margin="0,0,0,4" x:Uid="FAF_Color"/>
                                 <winui:ColorPicker Width="100" 
                                        Color="{x:Bind SelectedColor, Mode=TwoWay}"
                                        IsColorSliderVisible="False"

--- a/Quick Pad/Dialog/FontAndFormat.xaml
+++ b/Quick Pad/Dialog/FontAndFormat.xaml
@@ -19,16 +19,15 @@
         <local:FontFamilySpecificConverter x:Key="FontNameToFontFamily"/>
     </ContentDialog.Resources>
 
-    <ScrollViewer>
+    <ScrollViewer Width="500" Height="400">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="120"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <!--Fonts search-->
             <Grid>
@@ -52,10 +51,10 @@
                     <Style TargetType="ToggleButton">
                         <Setter Property="Margin" Value="0,5"/>
                         <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                        <Setter Property="MinHeight" Value="32"/>
+                        <Setter Property="MinHeight" Value="28"/>
                     </Style>
                 </StackPanel.Resources>
-                <ComboBox SelectedItem="{x:Bind FontSizeSelection, Mode=TwoWay}" Header="Size" w10v1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" MinWidth="69" BorderThickness="1">
+                <ComboBox SelectedItem="{x:Bind FontSizeSelection, Mode=TwoWay}" Header="Size" w10v1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" BorderThickness="1">
                     <x:Int32>4</x:Int32>
                     <x:Int32>6</x:Int32>
                     <x:Int32>8</x:Int32>
@@ -89,12 +88,15 @@
                 <ToggleButton IsChecked="{x:Bind WantStrikethrough, Mode=TwoWay}">
                     <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
                 </ToggleButton>
-            </StackPanel>
 
-            <!--Color-->
-            <StackPanel Grid.Column="2">
-                <TextBlock Text="Color" Margin="0,0,0,4"/>
-                <winui:ColorPicker Width="100" 
+                <!--Font color-->
+                <Button Margin="0,5" HorizontalAlignment="Stretch">
+                    <FontIcon Glyph="&#xE790;" />
+                    <Button.Flyout>
+                        <Flyout>
+                            <StackPanel Grid.Column="2">
+                                <TextBlock Text="Color" Margin="0,0,0,4"/>
+                                <winui:ColorPicker Width="100" 
                                        Color="{x:Bind SelectedColor, Mode=TwoWay}"
                                        IsColorSliderVisible="False"
                                        IsColorChannelTextInputVisible="False"
@@ -103,19 +105,21 @@
                                        IsAlphaSliderVisible="False"
                                        IsAlphaTextInputVisible="False"
                                        IsColorPreviewVisible="False"/>
+                            </StackPanel>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
             </StackPanel>
-
+            
             <!--Preview-->
-            <RichEditBox Style="{StaticResource RichEditBox}"
+            <ScrollViewer Grid.Column="0" MaxHeight="120" Grid.ColumnSpan="3" Margin="0,10" Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+                <RichEditBox Style="{StaticResource RichEditBox}"
                              IsHitTestVisible="False"
-                             Grid.Column="0"
-                         Grid.ColumnSpan="3"
-                         Margin="0,10"
-                         Grid.Row="1"
                              VerticalAlignment="Center"
                              HorizontalAlignment="Center"
                              x:Name="PreviewBox"
                              BorderThickness="0"/>
+            </ScrollViewer>
         </Grid>
     </ScrollViewer>
 </ContentDialog>

--- a/Quick Pad/Dialog/FontAndFormat.xaml
+++ b/Quick Pad/Dialog/FontAndFormat.xaml
@@ -1,0 +1,53 @@
+﻿<ContentDialog
+    x:Class="QuickPad.Dialog.FontAndFormat"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:QuickPad.Dialog"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:q="using:QuickPad"
+    mc:Ignorable="d"
+    Title="Fonts">
+    <ContentDialog.Resources>
+        <local:FontFamilySpecificConverter x:Key="FontNameToFontFamily"/>
+    </ContentDialog.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <!--Fonts search-->
+        <StackPanel Orientation="Vertical">
+            <AutoSuggestBox Text="{x:Bind FontNameSuggestionInput, UpdateSourceTrigger=PropertyChanged}"/>
+            <ListBox MinHeight="150" MinWidth="150" HorizontalAlignment="Stretch">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <StackPanel>
+                            <TextBlock Text="{x:Bind}" FontFamily="{Binding ,Converter={StaticResource FontNameToFontFamily}}"/>
+                            <TextBlock Text="{x:Bind}" Style="{ThemeResource CaptionTextBlockStyle}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </StackPanel>
+
+        <StackPanel Orientation="Vertical" Grid.Column="1">
+            <AutoSuggestBox Text="{x:Bind FontNameSuggestionInput, UpdateSourceTrigger=PropertyChanged}"/>
+            <ListBox MinHeight="150" MinWidth="150" HorizontalAlignment="Stretch">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <StackPanel>
+                            <TextBlock Text="{x:Bind}" FontFamily="{Binding ,Converter={StaticResource FontNameToFontFamily}}"/>
+                            <TextBlock Text="{x:Bind}" Style="{ThemeResource CaptionTextBlockStyle}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </StackPanel>
+    </Grid>
+</ContentDialog>

--- a/Quick Pad/Dialog/FontAndFormat.xaml.cs
+++ b/Quick Pad/Dialog/FontAndFormat.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Input;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI;
+using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -116,53 +117,92 @@ namespace QuickPad.Dialog
                     {
                         _name = value;
                         NotifyPropertyChanged(nameof(FontNameSuggestionInput));
+                        var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
+                        formatting.Name = value;
+                        PreviewBox.TextDocument.SetDefaultCharacterFormat(formatting);
                     }
                 }
             }
         }
         #endregion
-
+        
         #region Font size and other formatting
-        int _size;
+        int _size = 18;
         public int FontSizeSelection
         {
             get => _size;
-            set => Set(ref _size, value);
+            set
+            {
+                Set(ref _size, value);
+                var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
+                formatting.Size = value;
+                PreviewBox.TextDocument.SetDefaultCharacterFormat(formatting);
+            }
         }
 
         bool _bold;
         public bool WantBold
         {
             get => _bold;
-            set => Set(ref _bold, value);
+            set
+            {
+                Set(ref _bold, value);
+                var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
+                formatting.Bold = value ? FormatEffect.On : FormatEffect.Off;
+                PreviewBox.TextDocument.SetDefaultCharacterFormat(formatting);
+            }
         }
 
         bool _italic;
         public bool WantItalic
         {
             get => _italic;
-            set => Set(ref _italic, value);
+            set
+            {
+                Set(ref _italic, value);
+                var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
+                formatting.Italic = value ? FormatEffect.On : FormatEffect.Off;
+                PreviewBox.TextDocument.SetDefaultCharacterFormat(formatting);
+            }
         }
 
         bool _under;
         public bool WantUnderline
         {
             get => _under;
-            set => Set(ref _under, value);
+            set
+            {
+                Set(ref _under, value);
+                var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
+                formatting.Underline = value ? UnderlineType.Single : UnderlineType.None;
+                PreviewBox.TextDocument.SetDefaultCharacterFormat(formatting);
+            }
         }
 
         bool _strike;
         public bool WantStrikethrough
         {
             get => _strike;
-            set => Set(ref _strike, value);
+            set
+            {
+                Set(ref _strike, value);
+                var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
+                formatting.Strikethrough = value ? FormatEffect.On : FormatEffect.Off;
+                PreviewBox.TextDocument.SetDefaultCharacterFormat(formatting);
+            }
         }
 
         Color _sc;
         public Color SelectedColor
         {
             get => _sc;
-            set => Set(ref _sc, value);
+            set
+            {
+                Set(ref _sc, value);
+                var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
+                formatting.ForegroundColor = value;
+                PreviewBox.TextDocument.SetDefaultCharacterFormat(formatting);
+            }
         }
         #endregion
 
@@ -189,7 +229,19 @@ namespace QuickPad.Dialog
         {
             FinalResult = DialogResult.None;
             FilteredFonts = new ObservableCollection<string>(AllFonts);
-        }
+            PreviewBox.Document.SetText(TextSetOptions.None, "Preview");
+            //Apply settings
+            var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
+            formatting.Name = FontNameSuggestionInput;
+            formatting.Size = FontSizeSelection;
+            formatting.Bold = WantBold ? FormatEffect.On : FormatEffect.Off;
+            formatting.Italic = WantItalic ? FormatEffect.On : FormatEffect.Off;
+            formatting.Underline = WantUnderline ? UnderlineType.Single : UnderlineType.None;
+            formatting.Strikethrough = WantStrikethrough ? FormatEffect.On : FormatEffect.Off;
+            formatting.ForegroundColor = SelectedColor;
+            var sel = PreviewBox.Document.Selection;
+
+        }        
     }
 
     /// <summary>
@@ -200,6 +252,10 @@ namespace QuickPad.Dialog
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
+            if (value is null)
+            {
+                return new FontFamily("Segoe UI");
+            }
             return new FontFamily(value.ToString());
         }
 

--- a/Quick Pad/Dialog/FontAndFormat.xaml.cs
+++ b/Quick Pad/Dialog/FontAndFormat.xaml.cs
@@ -71,6 +71,9 @@ namespace QuickPad.Dialog
 
         #region Font name input
         string _name;
+        /// <summary>
+        /// This is a font input and also a final result
+        /// </summary>
         public string FontNameSuggestionInput
         {
             get => _name;
@@ -98,7 +101,81 @@ namespace QuickPad.Dialog
             get => _filtered;
             set => Set(ref _filtered, value);
         }
+
+        string _selected;
+        public string SelectedOnFilteredFont
+        {
+            get => _selected;
+            set
+            {
+                if (Set(ref _selected, value))
+                {
+                    //Selected and update
+                    //Should have put this onto input
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        FontNameSuggestionInput = value;
+                    }
+                }
+            }
+        }
         #endregion
+
+        #region Font size and other formatting
+        int _size;
+        public int FontSizeSelection
+        {
+            get => _size;
+            set => Set(ref _size, value);
+        }
+
+        bool _bold;
+        public bool WantBold
+        {
+            get => _bold;
+            set => Set(ref _bold, value);
+        }
+
+        bool _italic;
+        public bool WantItalic
+        {
+            get => _italic;
+            set => Set(ref _italic, value);
+        }
+
+        bool _under;
+        public bool WantUnderline
+        {
+            get => _under;
+            set => Set(ref _under, value);
+        }
+
+        bool _strike;
+        public bool WantStrikethrough
+        {
+            get => _strike;
+            set => Set(ref _strike, value);
+        }
+        #endregion
+
+        DialogResult _final;
+        public DialogResult FinalResult
+        {
+            get => _final;
+            set => Set(ref _final, value);
+        }
+
+        private void ApplyAllSettings()
+        {
+            FinalResult = DialogResult.Yes;
+            this.Hide();
+        }
+
+        private void DropEverything()
+        {
+            FinalResult = DialogResult.No;
+            this.Hide();            
+        }
     }
 
     /// <summary>

--- a/Quick Pad/Dialog/FontAndFormat.xaml.cs
+++ b/Quick Pad/Dialog/FontAndFormat.xaml.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Windows.Input;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace QuickPad.Dialog
+{
+    public sealed partial class FontAndFormat : ContentDialog, INotifyPropertyChanged
+    {
+        #region Notification overhead
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Set property and also alert the UI if the value is changed
+        /// </summary>
+        /// <param name="value">New value</param>
+        public bool Set<T>(ref T storage, T value, [CallerMemberName]string propertyName = null)
+        {
+            if (!Equals(storage, value))
+            {
+                storage = value;
+                NotifyPropertyChanged(propertyName);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Alert the UI there is a change in this property and need update
+        /// </summary>
+        /// <param name="name"></param>
+        public void NotifyPropertyChanged(string name)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+        #endregion
+        
+        public FontAndFormat()
+        {
+            this.InitializeComponent();
+            FilteredFonts = new ObservableCollection<string>(AllFonts);
+        }
+
+        public ObservableCollection<string> AllFonts
+        {
+            get => GetValue(AllFontsProperty) as ObservableCollection<string>;
+            set => SetValue(AllFontsProperty, value);
+        }
+        public static readonly DependencyProperty AllFontsProperty = 
+            DependencyProperty.Register(
+                nameof(AllFonts), 
+                typeof(ObservableCollection<string>), 
+                typeof(UserControl), 
+                new PropertyMetadata(null, null));
+
+        #region Font name input
+        string _name;
+        public string FontNameSuggestionInput
+        {
+            get => _name;
+            set
+            {
+                if (Set(ref _name, value))
+                {
+                    //Search matched result font
+                    var searched = AllFonts.ToList().FindAll(font => font.Contains(value));
+                    if (searched.Count < 1)
+                    {
+                        FilteredFonts = new ObservableCollection<string>(AllFonts);
+                    }
+                    else
+                    {
+                        FilteredFonts = new ObservableCollection<string>(searched);
+                    }
+                }
+            }
+        }
+
+        ObservableCollection<string> _filtered;
+        public ObservableCollection<string> FilteredFonts
+        {
+            get => _filtered;
+            set => Set(ref _filtered, value);
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// Due to the x:Bind limitation on DataTemplate, sending itself onto funtion isn't possible yet.
+    /// This is a workaround for now
+    /// </summary>
+    public class FontFamilySpecificConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return new FontFamily(value.ToString());
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            return (value as FontFamily).Source;
+        }
+    }
+}

--- a/Quick Pad/Dialog/FontAndFormat.xaml.cs
+++ b/Quick Pad/Dialog/FontAndFormat.xaml.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Windows.Input;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -54,7 +55,6 @@ namespace QuickPad.Dialog
         public FontAndFormat()
         {
             this.InitializeComponent();
-            FilteredFonts = new ObservableCollection<string>(AllFonts);
         }
 
         public ObservableCollection<string> AllFonts
@@ -112,9 +112,10 @@ namespace QuickPad.Dialog
                 {
                     //Selected and update
                     //Should have put this onto input
-                    if (string.IsNullOrEmpty(value))
+                    if (!string.IsNullOrEmpty(value))
                     {
-                        FontNameSuggestionInput = value;
+                        _name = value;
+                        NotifyPropertyChanged(nameof(FontNameSuggestionInput));
                     }
                 }
             }
@@ -156,6 +157,13 @@ namespace QuickPad.Dialog
             get => _strike;
             set => Set(ref _strike, value);
         }
+
+        Color _sc;
+        public Color SelectedColor
+        {
+            get => _sc;
+            set => Set(ref _sc, value);
+        }
         #endregion
 
         DialogResult _final;
@@ -175,6 +183,12 @@ namespace QuickPad.Dialog
         {
             FinalResult = DialogResult.No;
             this.Hide();            
+        }
+
+        private void ContentDialog_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+        {
+            FinalResult = DialogResult.None;
+            FilteredFonts = new ObservableCollection<string>(AllFonts);
         }
     }
 

--- a/Quick Pad/Dialog/FontAndFormat.xaml.cs
+++ b/Quick Pad/Dialog/FontAndFormat.xaml.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Windows.Input;
+using Windows.ApplicationModel.Resources;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI;
@@ -229,7 +230,7 @@ namespace QuickPad.Dialog
         {
             FinalResult = DialogResult.None;
             FilteredFonts = new ObservableCollection<string>(AllFonts);
-            PreviewBox.Document.SetText(TextSetOptions.None, "Preview");
+            PreviewBox.Document.SetText(TextSetOptions.None, ResourceLoader.GetForCurrentView().GetString("FAF_Preview_Initial"));
             //Apply settings
             var formatting = PreviewBox.Document.GetDefaultCharacterFormat();
             formatting.Name = FontNameSuggestionInput;

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -607,6 +607,8 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="10"/>
+                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <!--Save status-->
@@ -622,8 +624,12 @@
                 </Grid>
                 <!--Line and character count-->
                 <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" Grid.Column="1">
-                <Run Text="Ln "/><Run Text="{x:Bind totalLine, Mode=OneWay}"/><Run Text=","/>
-                <Run Text="Col "/><Run Text="{x:Bind totalCharacters, Mode=OneWay}"/>
+                <Run Text="Line: "/><Run Text="{x:Bind totalLine, Mode=OneWay}"/><Run Text=","/>
+                <Run Text="Column: "/><Run Text="{x:Bind totalCharacters, Mode=OneWay}"/>
+                </TextBlock>
+                <!--Selection info-->
+                <TextBlock VerticalAlignment="Center" Padding="5,0" Grid.Column="3" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(SelectionLength, q:IntCompare.More, 0), Mode=OneWay}">
+                    <Run Text="Selection: "/><Run Text="{x:Bind SelectionLength, Mode=OneWay}"/>
                 </TextBlock>
             </Grid>
         </controls:DropShadowPanel>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -584,7 +584,7 @@
         </CommandBar>
 
         <Grid Canvas.ZIndex="74" HorizontalAlignment="Stretch" Grid.Row="3" VerticalAlignment="Stretch" Padding="5,0,190,5" x:Name="StatusBar"
-              Visibility="{x:Bind q:Converter.CanIShowStatusBar(FocusModeSwitch, ClassicModeSwitch, QSetting.ShowStatusBar), Mode=OneWay}">
+              Visibility="{x:Bind q:Converter.CanIShowStatusBar(ClassicModeSwitch, QSetting.ShowStatusBar), Mode=OneWay}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -284,7 +284,11 @@
                 </MenuFlyoutItem>
             </winui:MenuBarItem>
             <winui:MenuBarItem Title="Format" x:Uid="ClassicFormat">
-                <ToggleMenuFlyoutItem Text="Word Wrap" IsChecked="{x:Bind QSetting.WordWrap, Mode=TwoWay}" x:Uid="WordWrap"/>
+                <ToggleMenuFlyoutItem Text="Word Wrap" IsChecked="{x:Bind QSetting.WordWrap, Mode=TwoWay}" x:Uid="WordWrap">
+                    <ToggleMenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE751;" />
+                    </ToggleMenuFlyoutItem.Icon>
+                </ToggleMenuFlyoutItem>
                 <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Bold" Click="Bold_Click" x:Uid="ClassicFormatBold">
                     <MenuFlyoutItem.Icon>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -8,6 +8,7 @@
     xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     xmlns:q="using:QuickPad"
     xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+    xmlns:dialog="using:QuickPad.Dialog"
     RequestedTheme="{x:Bind QSetting.Theme, Mode=OneWay}"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
@@ -543,6 +544,10 @@
                 </Pivot>
             </Grid>
         </ContentDialog>
+
+        <dialog:FontAndFormat x:Name="FontAndFormat" 
+                              Background="{ThemeResource SystemControlAcrylicElementBrush}" Grid.RowSpan="4"
+                              AllFonts="{x:Bind AllFonts, Mode=OneWay}"/>
 
         <controls:DropShadowPanel x:Name="Shadow2" Margin="0,0,0,0" Grid.RowSpan="4" VerticalAlignment="Bottom"
                                   Canvas.ZIndex="10"

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -77,34 +77,34 @@
                 </AppBarButton.KeyboardAccelerators>
             </AppBarButton>
             <AppBarSeparator/>
-            <AppBarButton x:Name="Bold" x:Uid="Bold"  Label="Bold"  Width="Auto" MinWidth="40" Click="Bold_Click" Icon="Bold" HorizontalAlignment="Stretch">
+            <AppBarToggleButton IsChecked="{x:Bind IsItBold, Mode=OneWay}" x:Name="Bold" x:Uid="Bold"  Label="Bold"  Width="Auto" MinWidth="40" Click="Bold_Click" Icon="Bold" HorizontalAlignment="Stretch">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Bold (Ctrl+B)" x:Uid="BoldTooltip"/>
                 </ToolTipService.ToolTip>
-            </AppBarButton>
-            <AppBarButton x:Name="Italic" x:Uid="Italic" Label="Italic" Width="Auto" MinWidth="40" Click="Italic_Click" Icon="Italic" HorizontalAlignment="Stretch">
+            </AppBarToggleButton>
+            <AppBarToggleButton IsChecked="{x:Bind IsItItalic, Mode=OneWay}" x:Name="Italic" x:Uid="Italic" Label="Italic" Width="Auto" MinWidth="40" Click="Italic_Click" Icon="Italic" HorizontalAlignment="Stretch">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Italic (Ctrl+I)" x:Uid="ItalicTooltip"/>
                 </ToolTipService.ToolTip>
-            </AppBarButton>
-            <AppBarButton x:Name="Underline" x:Uid="Underline" Label="Underline" Width="Auto" MinWidth="40" Click="Underline_Click" Icon="Underline" HorizontalAlignment="Stretch">
+            </AppBarToggleButton>
+            <AppBarToggleButton IsChecked="{x:Bind IsItUnderline, Mode=OneWay}" x:Name="Underline" x:Uid="Underline" Label="Underline" Width="Auto" MinWidth="40" Click="Underline_Click" Icon="Underline" HorizontalAlignment="Stretch">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Underline (Ctrl+U)" x:Uid="UnderlineTooltip"/>
                 </ToolTipService.ToolTip>
-            </AppBarButton>
-            <AppBarButton x:Name="Strikethrough" x:Uid="Strikethrough" Label="Strikethrough"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowStrikethroughOption), Mode=OneWay}" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="Strikethrough_Click">
+            </AppBarToggleButton>
+            <AppBarToggleButton IsChecked="{x:Bind IsItStrikethrough, Mode=OneWay}" x:Name="Strikethrough" x:Uid="Strikethrough" Label="Strikethrough"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowStrikethroughOption), Mode=OneWay}" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="Strikethrough_Click">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Strikethrough" x:Uid="StrikethroughTooltip"/>
                 </ToolTipService.ToolTip>
-                <AppBarButton.Icon>
+                <AppBarToggleButton.Icon>
                     <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
-                </AppBarButton.Icon>
-            </AppBarButton>
-            <AppBarButton x:Name="BulletList" x:Uid="BulletList"  Label="Bullets"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowBullets), Mode=OneWay}" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch">
+                </AppBarToggleButton.Icon>
+            </AppBarToggleButton>
+            <AppBarToggleButton IsChecked="{x:Bind IsUsingBulletList, Mode=OneWay}" x:Name="BulletList" x:Uid="BulletList"  Label="Bullets"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowBullets), Mode=OneWay}" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Toggle Bullets" x:Uid="BulletListTooltip"/>
                 </ToolTipService.ToolTip>
-            </AppBarButton>
+            </AppBarToggleButton>
             <AppBarSeparator/>
             <AppBarButton x:Name="Left" x:Uid="Left" Label="Left" Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignLeft), Mode=OneWay}" Click="Left_Click" Icon="AlignLeft">
                 <ToolTipService.ToolTip>
@@ -613,6 +613,11 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="10"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="10"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <!--Save status-->
@@ -635,6 +640,11 @@
                 <TextBlock VerticalAlignment="Center" Padding="5,0" Grid.Column="3" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(SelectionLength, q:IntCompare.More, 0), Mode=OneWay}">
                     <Run Text="Selection: "/><Run Text="{x:Bind SelectionLength, Mode=OneWay}"/>
                 </TextBlock>
+                <!--Bold, Italic, Underline status-->
+                <FontIcon FontSize="16" Glyph="&#xE8DD;" Grid.Column="5" Visibility="{x:Bind IsItBold, Mode=OneWay}"/>
+                <FontIcon FontSize="16" Glyph="&#xE8DB;" Grid.Column="6" Visibility="{x:Bind IsItItalic, Mode=OneWay}"/>
+                <FontIcon FontSize="16" Glyph="&#xE8DC;" Grid.Column="7" Visibility="{x:Bind IsItUnderline, Mode=OneWay}"/>
+                <FontIcon FontSize="16" Glyph="&#xA7A8;" FontFamily="Segoe UI" Grid.Column="7" Margin="0,0,0,2" Visibility="{x:Bind IsItStrikethrough, Mode=OneWay}"/>
             </Grid>
         </controls:DropShadowPanel>
         

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -600,7 +600,7 @@
                         </StackPanel>
                     </ToolTipService.ToolTip>
                 </SymbolIcon>
-                <Ellipse Width="8" Height="8" Fill="Red" HorizontalAlignment="Left" Margin="0,0,16,16" Visibility="{x:Bind q:Converter.BoolToVisibility(Changed)}"/>
+                <Ellipse Width="8" Height="8" Fill="Red" HorizontalAlignment="Left" Margin="0,0,16,16" Visibility="{x:Bind q:Converter.BoolToVisibility(Changed), Mode=OneWay}"/>
             </Grid>
             <!--Line and character count-->
             <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" Grid.Column="1">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -359,6 +359,12 @@
                         <FontIcon Glyph="&#xE158;" />
                     </ToggleMenuFlyoutItem.Icon>
                 </ToggleMenuFlyoutItem>
+                <MenuFlyoutSeparator/>
+                <ToggleMenuFlyoutItem Text="Status Bar" IsChecked="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}">
+                    <ToggleMenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE75B;" />
+                    </ToggleMenuFlyoutItem.Icon>
+                </ToggleMenuFlyoutItem>                
             </winui:MenuBarItem>
             <winui:MenuBarItem Title="Help" x:Uid="ClassicHelp">
                 <MenuFlyoutItem Text="Settings" Click="CmdSettings_Click" x:Uid="CmdSettingsTooltip">
@@ -420,7 +426,10 @@
                                     <ComboBoxItem Content="Focus Mode" Tag="Focus Mode" x:Uid="LaunchModeFocus" x:Name="LaunchModeFocus"/>
                                     <ComboBoxItem Content="Classic Mode" Tag="Classic Mode" x:Uid="LaunchModeClassic" x:Name="LaunchModeClassic"/>
                                 </ComboBox>
-                                
+
+                                <TextBlock Text="Show status bar"/>
+                                <ToggleSwitch IsOn="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}" x:Uid="GeneralToggleSwitch"/>
+
                                 <TextBlock x:Uid="GeneralDefaultType" Text="Default File Type"/>
                                 <ComboBox PlaceholderText=".rtf" SelectedItem="{x:Bind QSetting.DefaultFileType, Mode=TwoWay}" Windows10version1809:CornerRadius="2" x:Name="DefaultFileType" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="75" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
                                     <x:String>.rtf</x:String>
@@ -574,6 +583,32 @@
             <AppBarButton x:Name="Emoji" Width="40" Icon="Emoji2" Click="Emoji_Clicked" ToolTipService.ToolTip="Insert Emojis (Win + .)"/>
         </CommandBar>
 
+        <Grid Canvas.ZIndex="74" HorizontalAlignment="Stretch" Grid.Row="3" VerticalAlignment="Stretch" Padding="5,0,190,5" x:Name="StatusBar"
+              Visibility="{x:Bind q:Converter.CanIShowStatusBar(FocusModeSwitch, ClassicModeSwitch, QSetting.ShowStatusBar), Mode=OneWay}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Rectangle Fill="{ThemeResource AppBarBackgroundThemeBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="5"/>
+            <!--Save status-->
+            <Grid Margin="5,0,10,0" Visibility="{x:Bind q:Converter.ShowIfItemIsNotNull(CurrentWorkingFile), Mode=OneWay}">
+                <SymbolIcon Symbol="Save">
+                    <ToolTipService.ToolTip>
+                        <StackPanel>
+                            <TextBlock Text="{x:Bind CurrentWorkingFile.Path, Mode=OneWay}"/>
+                        </StackPanel>
+                    </ToolTipService.ToolTip>
+                </SymbolIcon>
+                <Ellipse Width="8" Height="8" Fill="Red" HorizontalAlignment="Left" Margin="0,0,16,16" Visibility="{x:Bind q:Converter.BoolToVisibility(Changed)}"/>
+            </Grid>
+            <!--Line and character count-->
+            <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" Grid.Column="1">
+                <Run Text="Ln "/><Run Text="{x:Bind totalLine, Mode=OneWay}"/><Run Text=","/>
+                <Run Text="Col "/><Run Text="{x:Bind totalCharacters, Mode=OneWay}"/>
+            </TextBlock>
+        </Grid>
+        
         <Grid x:Name="Title" Canvas.ZIndex="100" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" VerticalAlignment="Top" Height="33" HorizontalAlignment="Stretch">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="{x:Bind CurrentFilename, Mode=OneWay}"

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -594,31 +594,39 @@
             <AppBarButton x:Name="Emoji" Width="40" Icon="Emoji2" Click="Emoji_Clicked" ToolTipService.ToolTip="Insert Emojis (Win + .)"/>
         </CommandBar>
 
-        <Grid Canvas.ZIndex="74" HorizontalAlignment="Stretch" Grid.Row="3" VerticalAlignment="Stretch" Padding="5,0,190,5" x:Name="StatusBar"
-              Visibility="{x:Bind q:Converter.CanIShowStatusBar(ClassicModeSwitch, QSetting.ShowStatusBar), Mode=OneWay}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Rectangle Fill="{ThemeResource AppBarBackgroundThemeBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="5"/>
-            <!--Save status-->
-            <Grid Margin="5,0,10,0" Visibility="{x:Bind q:Converter.ShowIfItemIsNotNull(CurrentWorkingFile), Mode=OneWay}">
-                <SymbolIcon Symbol="Save">
-                    <ToolTipService.ToolTip>
-                        <StackPanel>
-                            <TextBlock Text="{x:Bind CurrentWorkingFile.Path, Mode=OneWay}"/>
-                        </StackPanel>
-                    </ToolTipService.ToolTip>
-                </SymbolIcon>
-                <Ellipse Width="8" Height="8" Fill="Red" HorizontalAlignment="Left" Margin="0,0,16,16" Visibility="{x:Bind q:Converter.BoolToVisibility(Changed), Mode=OneWay}"/>
-            </Grid>
-            <!--Line and character count-->
-            <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" Grid.Column="1">
+        <controls:DropShadowPanel Grid.RowSpan="4" 
+                                  VerticalAlignment="Bottom"
+                                  Canvas.ZIndex="10"
+                                  ShadowOpacity="0.2"
+                                  OffsetX="0"
+                                  OffsetY="-1"
+                                  HorizontalAlignment="Stretch"
+                                  HorizontalContentAlignment="Stretch"
+                                  Visibility="{x:Bind q:Converter.CanIShowStatusBar(ClassicModeSwitch, QSetting.ShowStatusBar), Mode=OneWay}">
+            <Grid Canvas.ZIndex="74" HorizontalAlignment="Stretch" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Grid.Row="3" VerticalAlignment="Stretch" x:Name="StatusBar" MinHeight="32">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <!--Save status-->
+                <Grid Margin="5,0,6,0" Visibility="{x:Bind q:Converter.ShowIfItemIsNotNull(CurrentWorkingFile), Mode=OneWay}">
+                    <SymbolIcon Symbol="Save">
+                        <ToolTipService.ToolTip>
+                            <StackPanel>
+                                <TextBlock Text="{x:Bind CurrentWorkingFile.Path, Mode=OneWay}"/>
+                            </StackPanel>
+                        </ToolTipService.ToolTip>
+                    </SymbolIcon>
+                    <Ellipse Width="8" Height="8" Fill="Red" HorizontalAlignment="Left" Margin="0,0,16,16" Visibility="{x:Bind q:Converter.BoolToVisibility(Changed), Mode=OneWay}"/>
+                </Grid>
+                <!--Line and character count-->
+                <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" Grid.Column="1">
                 <Run Text="Ln "/><Run Text="{x:Bind totalLine, Mode=OneWay}"/><Run Text=","/>
                 <Run Text="Col "/><Run Text="{x:Bind totalCharacters, Mode=OneWay}"/>
-            </TextBlock>
-        </Grid>
+                </TextBlock>
+            </Grid>
+        </controls:DropShadowPanel>
         
         <Grid x:Name="Title" Canvas.ZIndex="100" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" VerticalAlignment="Top" Height="33" HorizontalAlignment="Stretch">
             <StackPanel Orientation="Horizontal">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -348,7 +348,7 @@
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Fonts..." Click="ShowFontsDialog_Click">
+                <MenuFlyoutItem Text="Fonts..." Click="ShowFontsDialog_Click" x:Uid="ClassicFormatFonts">
                     <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Font"/>
                     </MenuFlyoutItem.Icon>
@@ -371,7 +371,7 @@
                     </ToggleMenuFlyoutItem.Icon>
                 </ToggleMenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <ToggleMenuFlyoutItem Text="Status Bar" IsChecked="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}">
+                <ToggleMenuFlyoutItem Text="Status Bar" IsChecked="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}" x:Uid="ClassicViewStatusBar">
                     <ToggleMenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE75B;" />
                     </ToggleMenuFlyoutItem.Icon>
@@ -633,12 +633,12 @@
                 </Grid>
                 <!--Line and character count-->
                 <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" Grid.Column="1">
-                <Run Text="Line: "/><Run Text="{x:Bind totalLine, Mode=OneWay}"/><Run Text=","/>
-                <Run Text="Column: "/><Run Text="{x:Bind totalCharacters, Mode=OneWay}"/>
+                <Run Text="Line: " x:Uid="StatusLnCount"/><Run Text="{x:Bind totalLine, Mode=OneWay}"/><Run Text=","/>
+                <Run Text="Column: " x:Uid="StatusColCount"/><Run Text="{x:Bind totalCharacters, Mode=OneWay}"/>
                 </TextBlock>
                 <!--Selection info-->
                 <TextBlock VerticalAlignment="Center" Padding="5,0" Grid.Column="3" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(SelectionLength, q:IntCompare.More, 0), Mode=OneWay}">
-                    <Run Text="Selection: "/><Run Text="{x:Bind SelectionLength, Mode=OneWay}"/>
+                    <Run Text="Selection: " x:Uid="StatusSelCount"/><Run Text="{x:Bind SelectionLength, Mode=OneWay}"/>
                 </TextBlock>
                 <!--Bold, Italic, Underline status-->
                 <FontIcon FontSize="16" Glyph="&#xE8DD;" Grid.Column="5" Visibility="{x:Bind IsItBold, Mode=OneWay}"/>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -427,8 +427,8 @@
                                     <ComboBoxItem Content="Classic Mode" Tag="Classic Mode" x:Uid="LaunchModeClassic" x:Name="LaunchModeClassic"/>
                                 </ComboBox>
 
-                                <TextBlock Text="Show status bar"/>
-                                <ToggleSwitch IsOn="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}" x:Uid="GeneralToggleSwitch"/>
+                                <TextBlock Text="Show status bar" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(QSetting.LaunchMode, q:IntCompare.Equal, 3), Mode=OneWay}"/>
+                                <ToggleSwitch IsOn="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}" x:Uid="GeneralToggleSwitch" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(QSetting.LaunchMode, q:IntCompare.Equal, 3), Mode=OneWay}"/>
 
                                 <TextBlock x:Uid="GeneralDefaultType" Text="Default File Type"/>
                                 <ComboBox PlaceholderText=".rtf" SelectedItem="{x:Bind QSetting.DefaultFileType, Mode=TwoWay}" Windows10version1809:CornerRadius="2" x:Name="DefaultFileType" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="75" HorizontalAlignment="Left" BorderThickness="1,1,1,1">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -343,6 +343,12 @@
                         <SymbolIcon Symbol="FontDecrease"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="Fonts..." Click="ShowFontsDialog_Click">
+                    <MenuFlyoutItem.Icon>
+                        <SymbolIcon Symbol="Font"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
             </winui:MenuBarItem>
             <winui:MenuBarItem Title="View" x:Uid="ClassicView">
                 <ToggleMenuFlyoutItem Text="Back to default mode" IsChecked="{x:Bind ClassicModeSwitch, Mode=TwoWay}" x:Uid="ClassicViewBack">

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1118,6 +1118,37 @@ namespace QuickPad
         {
             FontBoxFrame.Background = Fonts.Background; //Make the frame over the font box the same color as the font box
         }
+
+        private async void ShowFontsDialog_Click(object sender, RoutedEventArgs e)
+        {
+            //Get current text status
+            var selection = Text1.Document.Selection;
+            if (selection != null)
+            {
+                var formatting = selection.CharacterFormat;
+                //Update to dialog
+                FontAndFormat.FontNameSuggestionInput = formatting.Name;
+                FontAndFormat.FontSizeSelection = Convert.ToInt32(formatting.Size);
+                FontAndFormat.WantBold = formatting.Bold == FormatEffect.On;
+                FontAndFormat.WantItalic = formatting.Italic == FormatEffect.On;
+                FontAndFormat.WantUnderline = formatting.Underline != UnderlineType.None;
+                FontAndFormat.WantStrikethrough = formatting.Strikethrough == FormatEffect.On;
+                FontAndFormat.SelectedColor = formatting.ForegroundColor;
+            }
+            await FontAndFormat.ShowAsync();
+            //Apply setting back if user wanted to
+            if (FontAndFormat.FinalResult == DialogResult.Yes)
+            {
+                var formatting = selection.CharacterFormat;
+                formatting.Name = FontAndFormat.FontNameSuggestionInput;
+                formatting.Size = FontAndFormat.FontSizeSelection;
+                formatting.Bold = FontAndFormat.WantBold ? FormatEffect.On : FormatEffect.Off;
+                formatting.Italic = FontAndFormat.WantItalic ? FormatEffect.On : FormatEffect.Off;
+                formatting.Underline = FontAndFormat.WantUnderline ? UnderlineType.Single : UnderlineType.None;
+                formatting.Strikethrough = FontAndFormat.WantStrikethrough ? FormatEffect.On : FormatEffect.Off;
+                formatting.ForegroundColor = FontAndFormat.SelectedColor;
+            }
+        }
         #endregion
 
         #region UI Mode change

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1301,11 +1301,15 @@ namespace QuickPad
             {
                 CommandBar1.Visibility = Visibility.Collapsed;
                 CommandBar2.Visibility = Visibility.Collapsed;
+                CommandBar3.Visibility = Visibility.Collapsed;
+                Shadow2.Visibility = Visibility.Collapsed;
             }
             else
             {
                 CommandBar1.Visibility = Visibility.Visible;
                 CommandBar2.Visibility = Visibility.Visible;
+                CommandBar3.Visibility = Visibility.Visible;
+                Shadow2.Visibility = Visibility.Visible;
             }
         }
 

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1121,30 +1121,35 @@ namespace QuickPad
 
         private async void ShowFontsDialog_Click(object sender, RoutedEventArgs e)
         {
-            //Get current text status
-            var selection = Text1.Document.GetDefaultCharacterFormat();
+            //Force select all text
+            Text1.Focus(FocusState.Programmatic);
+            Text1.Document.Selection.SetRange(0, Text1.Document.Selection.EndPosition);
+            //Get format info about selection
+            var selection = Text1.Document.Selection;
             if (selection != null)
             {
+                var formatting = selection.CharacterFormat;
                 //Update to dialog
-                FontAndFormat.FontNameSuggestionInput = selection.Name;
-                FontAndFormat.FontSizeSelection = Convert.ToInt32(selection.Size);
-                FontAndFormat.WantBold = selection.Bold == FormatEffect.On;
-                FontAndFormat.WantItalic = selection.Italic == FormatEffect.On;
-                FontAndFormat.WantUnderline = selection.Underline != UnderlineType.None;
-                FontAndFormat.WantStrikethrough = selection.Strikethrough == FormatEffect.On;
-                FontAndFormat.SelectedColor = selection.ForegroundColor;
+                FontAndFormat.FontNameSuggestionInput = formatting.Name;
+                FontAndFormat.FontSizeSelection = Convert.ToInt32(formatting.Size);
+                FontAndFormat.WantBold = formatting.Bold == FormatEffect.On;
+                FontAndFormat.WantItalic = formatting.Italic == FormatEffect.On;
+                FontAndFormat.WantUnderline = formatting.Underline != UnderlineType.None;
+                FontAndFormat.WantStrikethrough = formatting.Strikethrough == FormatEffect.On;
+                FontAndFormat.SelectedColor = formatting.ForegroundColor;
             }
             await FontAndFormat.ShowAsync();
             //Apply setting back if user wanted to
             if (FontAndFormat.FinalResult == DialogResult.Yes)
             {
-                selection.Name = FontAndFormat.FontNameSuggestionInput;
-                selection.Size = FontAndFormat.FontSizeSelection;
-                selection.Bold = FontAndFormat.WantBold ? FormatEffect.On : FormatEffect.Off;
-                selection.Italic = FontAndFormat.WantItalic ? FormatEffect.On : FormatEffect.Off;
-                selection.Underline = FontAndFormat.WantUnderline ? UnderlineType.Single : UnderlineType.None;
-                selection.Strikethrough = FontAndFormat.WantStrikethrough ? FormatEffect.On : FormatEffect.Off;
-                selection.ForegroundColor = FontAndFormat.SelectedColor;
+                var formatting = selection.CharacterFormat;
+                formatting.Name = FontAndFormat.FontNameSuggestionInput;
+                formatting.Size = FontAndFormat.FontSizeSelection;
+                formatting.Bold = FontAndFormat.WantBold ? FormatEffect.On : FormatEffect.Off;
+                formatting.Italic = FontAndFormat.WantItalic ? FormatEffect.On : FormatEffect.Off;
+                formatting.Underline = FontAndFormat.WantUnderline ? UnderlineType.Single : UnderlineType.None;
+                formatting.Strikethrough = FontAndFormat.WantStrikethrough ? FormatEffect.On : FormatEffect.Off;
+                formatting.ForegroundColor = FontAndFormat.SelectedColor;
             }
         }
         #endregion

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1408,23 +1408,52 @@ namespace QuickPad
         private void Text1_SelectionChanged(object sender, RoutedEventArgs e)
         {
             FontSelected.Text = Text1.Document.Selection.CharacterFormat.Name; //updates font box to show the selected characters font
+            //Update selection info
+            if (Text1.Document.Selection is null)
+            {
+                SelectionLength = 0;
+            }
+            else
+            {
+                if (Text1.Document.Selection.Length < 0)
+                {
+                    SelectionLength = Text1.Document.Selection.Length * -1;
+                }
+                else
+                {
+                    SelectionLength = Text1.Document.Selection.Length;
+                }
+            }            
         }
 
         #endregion
 
         #region Status bar and update
-        public int _line;
+        private int _line;
+        /// <summary>
+        /// Line count
+        /// </summary>
         public int totalLine
         {
             get => _line;
             set => Set(ref _line, value);
         }
 
-        public int _char;
+        private int _char;
+        /// <summary>
+        /// Character count
+        /// </summary>
         public int totalCharacters
         {
             get => _char;
             set => Set(ref _char, value);
+        }
+
+        private int _selTT;
+        public int SelectionLength
+        {
+            get => _selTT;
+            set => Set(ref _selTT, value);
         }
         #endregion
     }

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -218,7 +218,6 @@ namespace QuickPad
                     SwitchFocusMode(true);
                     break;
                 case AvailableModes.OnTop:
-                    //TODO:Launch compact overlay mode
                     SwitchCompactOverlayMode(true);
                     break;
                 case AvailableModes.Classic:
@@ -1121,9 +1120,12 @@ namespace QuickPad
 
         private async void ShowFontsDialog_Click(object sender, RoutedEventArgs e)
         {
+            //Save selection point
+            int previousPosition = Text1.Document.Selection.StartPosition;
+            int previousSelectionEnd = Text1.Document.Selection.EndPosition;
             //Force select all text
             Text1.Focus(FocusState.Programmatic);
-            Text1.Document.Selection.SetRange(0, Text1.Document.Selection.EndPosition);
+            Text1.Document.Selection.SetRange(0, totalCharacters);
             //Get format info about selection
             var selection = Text1.Document.Selection;
             if (selection != null)
@@ -1151,6 +1153,17 @@ namespace QuickPad
                 formatting.Strikethrough = FontAndFormat.WantStrikethrough ? FormatEffect.On : FormatEffect.Off;
                 formatting.ForegroundColor = FontAndFormat.SelectedColor;
             }
+            //Restore to that point like nothing ever happen
+            if (previousPosition == previousSelectionEnd)
+            {
+                //Not select anything
+                Text1.Document.Selection.StartPosition = previousPosition;
+            }
+            else
+            {
+                //Select like what user used to
+                Text1.Document.Selection.SetRange(previousPosition, previousSelectionEnd);
+            }            
         }
         #endregion
 

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -477,9 +477,6 @@ namespace QuickPad
             Text1.Document.GetText(TextGetOptions.FormatRtf, out string ext);
             //
             Changed = !Equals(initialLoadedContent, ext);
-            //Update line and character count
-            totalCharacters = ext.Length;
-            totalLine = ext.Count(i => i == '\r');
         }
 
         public void SetANewChange()
@@ -1298,6 +1295,11 @@ namespace QuickPad
             CanRedoText = Text1.Document.CanRedo();
 
             CheckForChange(); //Check fof a change in document
+
+            //Update line and character count
+            Text1.Document.GetText(TextGetOptions.None, out string text);
+            totalCharacters = text.Length;
+            totalLine = text.Count(i => i == '\r');
         }
         /// <summary>
         /// Temporary store the copy of text when it loaded, 

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -477,6 +477,9 @@ namespace QuickPad
             Text1.Document.GetText(TextGetOptions.FormatRtf, out string ext);
             //
             Changed = !Equals(initialLoadedContent, ext);
+            //Update line and character count
+            totalCharacters = ext.Length;
+            totalLine = ext.Count(i => i == '\r');
         }
 
         public void SetANewChange()
@@ -487,8 +490,13 @@ namespace QuickPad
             //Update changed
             CheckForChange();
         }
-        
-        public StorageFile CurrentWorkingFile = null;
+
+        StorageFile _file;
+        public StorageFile CurrentWorkingFile
+        {
+            get => _file;
+            set => Set(ref _file, value);
+        }
         private string key; //future access list
 
         private bool _isPageLoaded = false;
@@ -1365,6 +1373,22 @@ namespace QuickPad
             FontSelected.Text = Text1.Document.Selection.CharacterFormat.Name; //updates font box to show the selected characters font
         }
 
+        #endregion
+
+        #region Status bar and update
+        public int _line;
+        public int totalLine
+        {
+            get => _line;
+            set => Set(ref _line, value);
+        }
+
+        public int _char;
+        public int totalCharacters
+        {
+            get => _char;
+            set => Set(ref _char, value);
+        }
         #endregion
     }
 

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1335,6 +1335,12 @@ namespace QuickPad
             Text1.Document.GetText(TextGetOptions.None, out string text);
             totalCharacters = text.Length;
             totalLine = text.Count(i => i == '\r');
+            //update current format
+            IsItBold = Text1.Document.Selection.CharacterFormat.Bold == FormatEffect.On;
+            IsItItalic = Text1.Document.Selection.CharacterFormat.Italic == FormatEffect.On;
+            IsItUnderline = Text1.Document.Selection.CharacterFormat.Underline != UnderlineType.None;
+            IsItStrikethrough = Text1.Document.Selection.CharacterFormat.Strikethrough == FormatEffect.On;
+            IsUsingBulletList = Text1.Document.Selection.ParagraphFormat.ListType != MarkerType.None;
         }
         /// <summary>
         /// Temporary store the copy of text when it loaded, 
@@ -1423,6 +1429,11 @@ namespace QuickPad
                 {
                     SelectionLength = Text1.Document.Selection.Length;
                 }
+                IsItBold = Text1.Document.Selection.CharacterFormat.Bold == FormatEffect.On;
+                IsItItalic = Text1.Document.Selection.CharacterFormat.Italic == FormatEffect.On;
+                IsItUnderline = Text1.Document.Selection.CharacterFormat.Underline != UnderlineType.None;
+                IsItStrikethrough = Text1.Document.Selection.CharacterFormat.Strikethrough == FormatEffect.On;
+                IsUsingBulletList = Text1.Document.Selection.ParagraphFormat.ListType != MarkerType.None;
             }            
         }
 
@@ -1454,6 +1465,39 @@ namespace QuickPad
         {
             get => _selTT;
             set => Set(ref _selTT, value);
+        }
+
+        private bool _bold, _italic, _underline;
+        public bool IsItBold
+        {
+            get => _bold;
+            set => Set(ref _bold, value);
+        }
+
+        public bool IsItItalic
+        {
+            get => _italic;
+            set => Set(ref _italic, value);
+        }
+
+        public bool IsItUnderline
+        {
+            get => _underline;
+            set => Set(ref _underline, value);
+        }
+
+        private bool _st;
+        public bool IsItStrikethrough
+        {
+            get => _st;
+            set => Set(ref _st, value);
+        }
+
+        private bool _bs;
+        public bool IsUsingBulletList
+        {
+            get => _bs;
+            set => Set(ref _bs, value);
         }
         #endregion
     }

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1122,31 +1122,29 @@ namespace QuickPad
         private async void ShowFontsDialog_Click(object sender, RoutedEventArgs e)
         {
             //Get current text status
-            var selection = Text1.Document.Selection;
+            var selection = Text1.Document.GetDefaultCharacterFormat();
             if (selection != null)
             {
-                var formatting = selection.CharacterFormat;
                 //Update to dialog
-                FontAndFormat.FontNameSuggestionInput = formatting.Name;
-                FontAndFormat.FontSizeSelection = Convert.ToInt32(formatting.Size);
-                FontAndFormat.WantBold = formatting.Bold == FormatEffect.On;
-                FontAndFormat.WantItalic = formatting.Italic == FormatEffect.On;
-                FontAndFormat.WantUnderline = formatting.Underline != UnderlineType.None;
-                FontAndFormat.WantStrikethrough = formatting.Strikethrough == FormatEffect.On;
-                FontAndFormat.SelectedColor = formatting.ForegroundColor;
+                FontAndFormat.FontNameSuggestionInput = selection.Name;
+                FontAndFormat.FontSizeSelection = Convert.ToInt32(selection.Size);
+                FontAndFormat.WantBold = selection.Bold == FormatEffect.On;
+                FontAndFormat.WantItalic = selection.Italic == FormatEffect.On;
+                FontAndFormat.WantUnderline = selection.Underline != UnderlineType.None;
+                FontAndFormat.WantStrikethrough = selection.Strikethrough == FormatEffect.On;
+                FontAndFormat.SelectedColor = selection.ForegroundColor;
             }
             await FontAndFormat.ShowAsync();
             //Apply setting back if user wanted to
             if (FontAndFormat.FinalResult == DialogResult.Yes)
             {
-                var formatting = selection.CharacterFormat;
-                formatting.Name = FontAndFormat.FontNameSuggestionInput;
-                formatting.Size = FontAndFormat.FontSizeSelection;
-                formatting.Bold = FontAndFormat.WantBold ? FormatEffect.On : FormatEffect.Off;
-                formatting.Italic = FontAndFormat.WantItalic ? FormatEffect.On : FormatEffect.Off;
-                formatting.Underline = FontAndFormat.WantUnderline ? UnderlineType.Single : UnderlineType.None;
-                formatting.Strikethrough = FontAndFormat.WantStrikethrough ? FormatEffect.On : FormatEffect.Off;
-                formatting.ForegroundColor = FontAndFormat.SelectedColor;
+                selection.Name = FontAndFormat.FontNameSuggestionInput;
+                selection.Size = FontAndFormat.FontSizeSelection;
+                selection.Bold = FontAndFormat.WantBold ? FormatEffect.On : FormatEffect.Off;
+                selection.Italic = FontAndFormat.WantItalic ? FormatEffect.On : FormatEffect.Off;
+                selection.Underline = FontAndFormat.WantUnderline ? UnderlineType.Single : UnderlineType.None;
+                selection.Strikethrough = FontAndFormat.WantStrikethrough ? FormatEffect.On : FormatEffect.Off;
+                selection.ForegroundColor = FontAndFormat.SelectedColor;
             }
         }
         #endregion

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
@@ -650,6 +650,42 @@
           <source>Exit the app</source>
           <target state="new">Exit the app</target>
         </trans-unit>
+        <trans-unit id="ClassicFormatFonts.Text" translate="yes" xml:space="preserve">
+          <source>Fonts...</source>
+          <target state="new">Fonts...</target>
+        </trans-unit>
+        <trans-unit id="ClassicViewStatusBar.Text" translate="yes" xml:space="preserve">
+          <source>Status Bar</source>
+          <target state="new">Status Bar</target>
+        </trans-unit>
+        <trans-unit id="FAF_Color.Text" translate="yes" xml:space="preserve">
+          <source>Color</source>
+          <target state="new">Color</target>
+        </trans-unit>
+        <trans-unit id="FAF_Fonts.Text" translate="yes" xml:space="preserve">
+          <source>Fonts</source>
+          <target state="new">Fonts</target>
+        </trans-unit>
+        <trans-unit id="FAF_Preview_Initial" translate="yes" xml:space="preserve">
+          <source>Preview</source>
+          <target state="new">Preview</target>
+        </trans-unit>
+        <trans-unit id="FAF_Size.Text" translate="yes" xml:space="preserve">
+          <source>Size</source>
+          <target state="new">Size</target>
+        </trans-unit>
+        <trans-unit id="StatusColCount.Text" translate="yes" xml:space="preserve">
+          <source>Column: </source>
+          <target state="new">Column: </target>
+        </trans-unit>
+        <trans-unit id="StatusLnCount.Text" translate="yes" xml:space="preserve">
+          <source>Line: </source>
+          <target state="new">Line: </target>
+        </trans-unit>
+        <trans-unit id="StatusSelCount.Text" translate="yes" xml:space="preserve">
+          <source>Selection: </source>
+          <target state="new">Selection: </target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -628,13 +628,11 @@
         </trans-unit>
         <trans-unit id="ClassicViewFocus.Text" translate="yes" xml:space="preserve">
           <source>Focus Mode</source>
-          <target state="needs-review-translation">เน้นพิมพ์</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">เน้นพิมพ์</target>
         </trans-unit>
         <trans-unit id="ClassicViewOverlay.Text" translate="yes" xml:space="preserve">
           <source>On Top Mode</source>
-          <target state="needs-review-translation">ทับแอปอื่น</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">ทับแอปอื่น</target>
         </trans-unit>
         <trans-unit id="ClassicView.Title" translate="yes" xml:space="preserve">
           <source>View</source>
@@ -651,6 +649,42 @@
         <trans-unit id="CmdExitTooltip.Text" translate="yes" xml:space="preserve">
           <source>Exit the app</source>
           <target state="translated">ปิดแอปไปทำอย่างอื่น</target>
+        </trans-unit>
+        <trans-unit id="ClassicFormatFonts.Text" translate="yes" xml:space="preserve">
+          <source>Fonts...</source>
+          <target state="translated">แบบอักษร</target>
+        </trans-unit>
+        <trans-unit id="ClassicViewStatusBar.Text" translate="yes" xml:space="preserve">
+          <source>Status Bar</source>
+          <target state="translated">แถบสถานะ</target>
+        </trans-unit>
+        <trans-unit id="FAF_Color.Text" translate="yes" xml:space="preserve">
+          <source>Color</source>
+          <target state="translated">สี</target>
+        </trans-unit>
+        <trans-unit id="FAF_Fonts.Text" translate="yes" xml:space="preserve">
+          <source>Fonts</source>
+          <target state="translated">แบบอักษร</target>
+        </trans-unit>
+        <trans-unit id="FAF_Preview_Initial" translate="yes" xml:space="preserve">
+          <source>Preview</source>
+          <target state="translated">ตัวอย่าง</target>
+        </trans-unit>
+        <trans-unit id="FAF_Size.Text" translate="yes" xml:space="preserve">
+          <source>Size</source>
+          <target state="translated">ขนาด</target>
+        </trans-unit>
+        <trans-unit id="StatusColCount.Text" translate="yes" xml:space="preserve">
+          <source>Column: </source>
+          <target state="translated">ตัว: </target>
+        </trans-unit>
+        <trans-unit id="StatusLnCount.Text" translate="yes" xml:space="preserve">
+          <source>Line: </source>
+          <target state="translated">บรรทัด: </target>
+        </trans-unit>
+        <trans-unit id="StatusSelCount.Text" translate="yes" xml:space="preserve">
+          <source>Selection: </source>
+          <target state="translated">เลือก: </target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/Quick Pad.csproj
+++ b/Quick Pad/Quick Pad.csproj
@@ -134,6 +134,9 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Dialog\FontAndFormat.xaml.cs">
+      <DependentUpon>FontAndFormat.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Dialog\SaveChange.xaml.cs">
       <DependentUpon>SaveChange.xaml</DependentUpon>
     </Compile>
@@ -217,6 +220,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="Dialog\FontAndFormat.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Dialog\SaveChange.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -533,6 +533,11 @@ namespace QuickPad
         {
             return CompareNumber(number, compareType, target) ? Visibility.Visible : Visibility.Collapsed;
         }
+
+        public static FontFamily FontNameToFontFamily(string name)
+        {
+            return new FontFamily(name);
+        }
     }
 
     public static class IntCompare

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -170,6 +170,13 @@ namespace QuickPad
             set => Set(value);
         }
 
+        [DefaultValue(false)]
+        public bool ShowStatusBar
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
         /// <summary>
         /// this is to check the default file extension choosen in the save file dialog
         /// </summary>
@@ -455,6 +462,44 @@ namespace QuickPad
             byte g = (byte)Convert.ToUInt32(input.Substring(4, 2), 16);
             byte b = (byte)Convert.ToUInt32(input.Substring(6, 2), 16);
             return Color.FromArgb(a, r, g, b);
+        }
+
+        /// <summary>
+        /// Use to check if input item is null or not
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static bool IsItemNull(object item)
+        {
+            return item is null;
+        }
+
+        /// <summary>
+        /// Use in XAML binding, if item is null show that UI, if item is not null hide the UI
+        /// </summary>
+        /// <param name="input">anything</param>
+        /// <returns></returns>
+        public static Visibility ShowIfItemIsNull(object input) => IsItemNull(input) ? Visibility.Visible : Visibility.Collapsed;
+
+        /// <summary>
+        /// Use in XAML binding, if item is null hide that UI, if item is not null show the UI
+        /// </summary>
+        /// <param name="input">anything</param>
+        /// <returns></returns>
+        public static Visibility ShowIfItemIsNotNull(object input) => IsItemNull(input) ? Visibility.Collapsed : Visibility.Visible;
+
+        public static Visibility CanIShowStatusBar(bool focusMode, bool classicMode, bool showStatusBar)
+        {
+            //Is it either focus mode or classic mode?
+            if (focusMode || classicMode)
+            {
+                //If it on either mode, is it allow to show status bar?
+                if (showStatusBar)
+                {
+                    return Visibility.Visible;
+                }
+            }
+            return Visibility.Collapsed;
         }
     }
 }

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -488,10 +488,10 @@ namespace QuickPad
         /// <returns></returns>
         public static Visibility ShowIfItemIsNotNull(object input) => IsItemNull(input) ? Visibility.Collapsed : Visibility.Visible;
 
-        public static Visibility CanIShowStatusBar(bool focusMode, bool classicMode, bool showStatusBar)
+        public static Visibility CanIShowStatusBar(bool classicMode, bool showStatusBar)
         {
-            //Is it either focus mode or classic mode?
-            if (focusMode || classicMode)
+            //Is it classic mode?
+            if (classicMode)
             {
                 //If it on either mode, is it allow to show status bar?
                 if (showStatusBar)
@@ -501,5 +501,47 @@ namespace QuickPad
             }
             return Visibility.Collapsed;
         }
+
+        /// <summary>
+        /// Use to compare number and return boolean
+        /// </summary>
+        /// <param name="input">Number input</param>
+        /// <param name="compare">Compare type</param>
+        /// <param name="target">Number to compare to</param>
+        /// <returns></returns>
+        public static bool CompareNumber(int input, string compare, int target)
+        {
+            switch (compare)
+            {
+                case IntCompare.NotEqual:
+                    return input != target;
+                case IntCompare.LessOrEqual:
+                    return input <= target;
+                case IntCompare.MoreOrEqual:
+                    return input >= target;
+                case IntCompare.Less:
+                    return input < target;
+                case IntCompare.More:
+                    return input > target;
+                case IntCompare.Equal:
+                default:
+                    return input == target;
+            }
+        }
+
+        public static Visibility ShowAfterCompareNumber(int number, string compareType, int target)
+        {
+            return CompareNumber(number, compareType, target) ? Visibility.Visible : Visibility.Collapsed;
+        }
+    }
+
+    public static class IntCompare
+    {
+        public const string Equal = "=";
+        public const string NotEqual = "!=";
+        public const string Less = "<";
+        public const string More = ">";
+        public const string LessOrEqual = "<=";
+        public const string MoreOrEqual = ">=";
     }
 }

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -600,4 +600,31 @@
   <data name="CmdExitTooltip.Text" xml:space="preserve">
     <value>Exit the app</value>
   </data>
+  <data name="ClassicFormatFonts.Text" xml:space="preserve">
+    <value>Fonts...</value>
+  </data>
+  <data name="ClassicViewStatusBar.Text" xml:space="preserve">
+    <value>Status Bar</value>
+  </data>
+  <data name="FAF_Color.Text" xml:space="preserve">
+    <value>Color</value>
+  </data>
+  <data name="FAF_Fonts.Text" xml:space="preserve">
+    <value>Fonts</value>
+  </data>
+  <data name="FAF_Preview_Initial" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="FAF_Size.Text" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="StatusColCount.Text" xml:space="preserve">
+    <value>Column: </value>
+  </data>
+  <data name="StatusLnCount.Text" xml:space="preserve">
+    <value>Line: </value>
+  </data>
+  <data name="StatusSelCount.Text" xml:space="preserve">
+    <value>Selection: </value>
+  </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -495,4 +495,31 @@
   <data name="CmdExitTooltip.Text" xml:space="preserve">
     <value>ปิดแอปไปทำอย่างอื่น</value>
   </data>
+  <data name="ClassicFormatFonts.Text" xml:space="preserve">
+    <value>แบบอักษร</value>
+  </data>
+  <data name="ClassicViewStatusBar.Text" xml:space="preserve">
+    <value>แถบสถานะ</value>
+  </data>
+  <data name="FAF_Color.Text" xml:space="preserve">
+    <value>สี</value>
+  </data>
+  <data name="FAF_Fonts.Text" xml:space="preserve">
+    <value>แบบอักษร</value>
+  </data>
+  <data name="FAF_Preview_Initial" xml:space="preserve">
+    <value>ตัวอย่าง</value>
+  </data>
+  <data name="FAF_Size.Text" xml:space="preserve">
+    <value>ขนาด</value>
+  </data>
+  <data name="StatusColCount.Text" xml:space="preserve">
+    <value>ตัว: </value>
+  </data>
+  <data name="StatusLnCount.Text" xml:space="preserve">
+    <value>บรรทัด: </value>
+  </data>
+  <data name="StatusSelCount.Text" xml:space="preserve">
+    <value>เลือก: </value>
+  </data>
 </root>


### PR DESCRIPTION
### Status bar
- A Status bar that show only on Classic Mode
- The counting information are: Line count, Character count, Selection count
- The display icon are: Saving status (Hover will show file path, show red dot when a change has made), Bold status, Italic status, Underline status, Strikethrough status
- A new setting that will only show if "Default launch mode" is set to "Classic"; a setting to turn on status bar 

### Addition
#### Font and format dialog
- A dialog to set format to every characters
- It will select all text and restore user selection when dialog is closed
- A font name selection that will filter when writing on it
- A color picker that user can select any font color as they pleased
- A preview at the bottom to showcase all user selection so far

#### Others
- Hide font selection, font color, emoji command bar on classic mode
- Adding custom shadow pane for status bar
- Adding icon for word wrap on classic menu bar
- Show accent color over "Bold", "Italic", "Underline", "Strikethrough", and "Bullets" on Default menu bar to indicate if it is bold, italic etc. 
