### PR TITLE
Addressing the issue #34

### DIFF
--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -440,9 +440,6 @@
                                     <ComboBoxItem Content="Classic Mode" Tag="Classic Mode" x:Uid="LaunchModeClassic" x:Name="LaunchModeClassic"/>
                                 </ComboBox>
 
-                                <TextBlock Text="Show status bar" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(QSetting.LaunchMode, q:IntCompare.Equal, 3), Mode=OneWay}"/>
-                                <ToggleSwitch IsOn="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}" x:Uid="GeneralToggleSwitch" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(QSetting.LaunchMode, q:IntCompare.Equal, 3), Mode=OneWay}"/>
-
                                 <TextBlock x:Uid="GeneralDefaultType" Text="Default File Type"/>
                                 <ComboBox PlaceholderText=".rtf" SelectedItem="{x:Bind QSetting.DefaultFileType, Mode=TwoWay}" Windows10version1809:CornerRadius="2" x:Name="DefaultFileType" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="75" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
                                     <x:String>.rtf</x:String>
@@ -457,6 +454,10 @@
                                 
                                 <TextBlock x:Uid="SpellCheck" Text="Spell Check"/>
                                 <ToggleSwitch x:Name="SpellCheck" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" IsOn="{x:Bind QSetting.SpellCheck, Mode=TwoWay}"/>
+
+                                <TextBlock Text="Show Status Bar on Classic Mode"/>
+                                <ToggleSwitch IsOn="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}" x:Uid="GeneralToggleSwitch"/>
+
                             </StackPanel>
                         </ScrollViewer>
                     </PivotItem>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -405,7 +405,9 @@
                      VerticalAlignment="Stretch" 
                      TextWrapping="{x:Bind q:Converter.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" 
                      IsSpellCheckEnabled="{x:Bind QSetting.SpellCheck, Mode=OneWay}" 
-                     Style="{StaticResource RichEditBox}"/>
+                     Style="{StaticResource RichEditBox}"
+                     IsTapEnabled="True"
+                     Tapped="Text1_Tapped"/>
 
         <ContentDialog x:Name="Settings" Windows10version1809:CornerRadius="4" Background="{ThemeResource SystemControlAcrylicElementBrush}" BorderBrush="{ThemeResource SystemControlForegroundBaseLowBrush}" Opened="Settings_Opened" Grid.Row="0" Grid.RowSpan="4">
             <ContentDialog.Resources>
@@ -633,8 +635,8 @@
                 </Grid>
                 <!--Line and character count-->
                 <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" FontSize="14" Grid.Column="1" Margin="5,0,0,0">
-                <Run Text="Line: " x:Uid="StatusLnCount"/><Run Text="{x:Bind totalLine, Mode=OneWay}"/><Run Text=","/>
-                <Run Text="Column: " x:Uid="StatusColCount"/><Run Text="{x:Bind totalCharacters, Mode=OneWay}"/>
+                <Run Text="Line: " x:Uid="StatusLnCount"/><Run Text="{x:Bind CurrentPosition, Mode=OneWay}"/><Run Text=","/>
+                <Run Text="Column: " x:Uid="StatusColCount"/><Run Text="{x:Bind CurrentLine, Mode=OneWay}"/>
                 </TextBlock>
                 <!--Selection info-->
                 <TextBlock VerticalAlignment="Center" Padding="5,0" Grid.Column="3" FontSize="14" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(SelectionLength, q:IntCompare.More, 0), Mode=OneWay}">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -623,20 +623,20 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <!--Save status-->
-                <Grid Margin="5,0,6,0" Visibility="{x:Bind q:Converter.ShowIfItemIsNotNull(CurrentWorkingFile), Mode=OneWay}">
-                    <SymbolIcon Symbol="Save">
+                <Grid Margin="5,0,2,0" Visibility="{x:Bind q:Converter.ShowIfItemIsNotNull(CurrentWorkingFile), Mode=OneWay}" Width="32" MaxWidth="32">
+                    <FontIcon Glyph="&#xE74E;" FontSize="14">
                         <ToolTipService.ToolTip>
                             <StackPanel>
                                 <TextBlock Text="{x:Bind CurrentWorkingFile.Path, Mode=OneWay}"/>
                             </StackPanel>
                         </ToolTipService.ToolTip>
-                    </SymbolIcon>
-                    <Ellipse Width="8" Height="8" Fill="Red" HorizontalAlignment="Left" Margin="0,0,16,16" Visibility="{x:Bind q:Converter.BoolToVisibility(Changed), Mode=OneWay}"/>
+                    </FontIcon>
+                    <Ellipse Width="8" Height="8" Fill="Red" HorizontalAlignment="Left" Margin="4,0,0,8" Visibility="{x:Bind q:Converter.BoolToVisibility(Changed), Mode=OneWay}"/>
                 </Grid>
                 <!--Line and character count-->
-                <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" FontSize="14" Grid.Column="1" Margin="5,0,0,0">
-                <Run Text="Line: " x:Uid="StatusLnCount"/><Run Text="{x:Bind CurrentPosition, Mode=OneWay}"/><Run Text=","/>
-                <Run Text="Column: " x:Uid="StatusColCount"/><Run Text="{x:Bind CurrentLine, Mode=OneWay}"/>
+                <TextBlock VerticalAlignment="Center" Padding="5,0,10,0" FontSize="14" Grid.Column="1" Margin="0,0,0,0">
+                <Run Text="Line: " x:Uid="StatusLnCount"/><Run Text="{x:Bind CurrentLine, Mode=OneWay}"/><Run Text=","/>
+                <Run Text="Column: " x:Uid="StatusColCount"/><Run Text="{x:Bind CurrentPosition, Mode=OneWay}"/>
                 </TextBlock>
                 <!--Selection info-->
                 <TextBlock VerticalAlignment="Center" Padding="5,0" Grid.Column="3" FontSize="14" Visibility="{x:Bind q:Converter.ShowAfterCompareNumber(SelectionLength, q:IntCompare.More, 0), Mode=OneWay}">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -455,7 +455,7 @@
                                 <TextBlock x:Uid="SpellCheck" Text="Spell Check"/>
                                 <ToggleSwitch x:Name="SpellCheck" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" IsOn="{x:Bind QSetting.SpellCheck, Mode=TwoWay}"/>
 
-                                <TextBlock Text="Show Status Bar on Classic Mode"/>
+                                <TextBlock Text="Show Status Bar on Classic Mode" x:Uid="GeneralShowStatusOnClassic"/>
                                 <ToggleSwitch IsOn="{x:Bind QSetting.ShowStatusBar, Mode=TwoWay}" x:Uid="GeneralToggleSwitch"/>
 
                             </StackPanel>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -598,7 +598,7 @@
             <AppBarButton x:Name="Emoji" Width="40" Icon="Emoji2" Click="Emoji_Clicked" ToolTipService.ToolTip="Insert Emojis (Win + .)"/>
         </CommandBar>
 
-        <controls:DropShadowPanel Grid.RowSpan="4" 
+        <controls:DropShadowPanel Grid.Row="3"
                                   VerticalAlignment="Bottom"
                                   Canvas.ZIndex="10"
                                   ShadowOpacity="0.2"

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -411,7 +411,19 @@ namespace QuickPad
                     Set(ref _fc_selection, value);
                     //Update setting
                     QSetting.DefaultFontColor = FontColorCollections[value].TechnicalName;
-                    Text1.Document.Selection.CharacterFormat.ForegroundColor = FontColorCollections[value].ActualColor;
+                    if (QSetting.DefaultFontColor == "Default")
+                    {
+                        bool isDarkTheme = RequestedTheme == ElementTheme.Dark;
+                        if (RequestedTheme == ElementTheme.Default)
+                        {
+                            isDarkTheme = App.Current.RequestedTheme == ApplicationTheme.Dark;
+                        }
+                        Text1.Document.Selection.CharacterFormat.ForegroundColor = isDarkTheme ? Colors.White : Colors.Black;
+                    }
+                    else
+                    {
+                        Text1.Document.Selection.CharacterFormat.ForegroundColor = FontColorCollections[value].ActualColor;
+                    }
                 }
             }
         }

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1347,16 +1347,10 @@ namespace QuickPad
 
             CheckForChange(); //Check fof a change in document
 
-            //Update line and character count
-            Text1.Document.GetText(TextGetOptions.None, out string text);
-            totalCharacters = text.Length;
-            totalLine = text.Count(i => i == '\r');
-            //update current format
-            IsItBold = Text1.Document.Selection.CharacterFormat.Bold == FormatEffect.On;
-            IsItItalic = Text1.Document.Selection.CharacterFormat.Italic == FormatEffect.On;
-            IsItUnderline = Text1.Document.Selection.CharacterFormat.Underline != UnderlineType.None;
-            IsItStrikethrough = Text1.Document.Selection.CharacterFormat.Strikethrough == FormatEffect.On;
-            IsUsingBulletList = Text1.Document.Selection.ParagraphFormat.ListType != MarkerType.None;
+            if (ClassicModeSwitch)
+            {
+                
+            }
         }
         /// <summary>
         /// Temporary store the copy of text when it loaded, 
@@ -1379,6 +1373,10 @@ namespace QuickPad
             {
                 Text1.Document.EndUndoGroup();
                 Text1.Document.BeginUndoGroup();
+            }
+            if (ClassicModeSwitch)
+            {
+                CheckForStatusUpdate();
             }
         }
 
@@ -1430,7 +1428,35 @@ namespace QuickPad
         private void Text1_SelectionChanged(object sender, RoutedEventArgs e)
         {
             FontSelected.Text = Text1.Document.Selection.CharacterFormat.Name; //updates font box to show the selected characters font
-            //Update selection info
+
+            //Update Status bar
+            CheckForStatusUpdate();
+        }
+
+        private void Text1_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            CheckForStatusUpdate();
+        }
+
+        #endregion
+
+        #region Status bar and update
+        public void CheckForStatusUpdate()
+        {
+            //Update line and character count
+            Text1.Document.GetText(TextGetOptions.None, out string text);
+            totalCharacters = text.Length;
+            totalLine = text.Count(i => i == '\r');
+            CurrentPosition = Text1.Document.Selection.StartPosition + 1;
+            string sub = text.Substring(0, Text1.Document.Selection.StartPosition);
+            CurrentLine = sub.Count(i => i == '\r') + 1;
+            //update current format
+            IsItBold = Text1.Document.Selection.CharacterFormat.Bold == FormatEffect.On;
+            IsItItalic = Text1.Document.Selection.CharacterFormat.Italic == FormatEffect.On;
+            IsItUnderline = Text1.Document.Selection.CharacterFormat.Underline != UnderlineType.None;
+            IsItStrikethrough = Text1.Document.Selection.CharacterFormat.Strikethrough == FormatEffect.On;
+            IsUsingBulletList = Text1.Document.Selection.ParagraphFormat.ListType != MarkerType.None;
+            //Selection update
             if (Text1.Document.Selection is null)
             {
                 SelectionLength = 0;
@@ -1445,17 +1471,9 @@ namespace QuickPad
                 {
                     SelectionLength = Text1.Document.Selection.Length;
                 }
-                IsItBold = Text1.Document.Selection.CharacterFormat.Bold == FormatEffect.On;
-                IsItItalic = Text1.Document.Selection.CharacterFormat.Italic == FormatEffect.On;
-                IsItUnderline = Text1.Document.Selection.CharacterFormat.Underline != UnderlineType.None;
-                IsItStrikethrough = Text1.Document.Selection.CharacterFormat.Strikethrough == FormatEffect.On;
-                IsUsingBulletList = Text1.Document.Selection.ParagraphFormat.ListType != MarkerType.None;
-            }            
+            }
         }
 
-        #endregion
-
-        #region Status bar and update
         private int _line;
         /// <summary>
         /// Line count
@@ -1474,6 +1492,20 @@ namespace QuickPad
         {
             get => _char;
             set => Set(ref _char, value);
+        }
+
+        private int _cp;
+        public int CurrentPosition
+        {
+            get => _cp;
+            set => Set(ref _cp, value);
+        }
+
+        private int _cl;
+        public int CurrentLine
+        {
+            get => _cl;
+            set => Set(ref _cl, value);
         }
 
         private int _selTT;
@@ -1508,7 +1540,7 @@ namespace QuickPad
             get => _st;
             set => Set(ref _st, value);
         }
-
+        
         private bool _bs;
         public bool IsUsingBulletList
         {

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -201,6 +201,11 @@ namespace QuickPad
             if (QSetting.DefaultFontColor == "Default")
             {
                 Text1.Document.Selection.CharacterFormat.ForegroundColor = isDarkTheme ? Colors.White : Colors.Black;
+                if (totalCharacters < 2)
+                {
+                    //Nothing is written maybe update initial source
+                    SetANewChange();
+                }
             }
         }
 

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
@@ -559,8 +559,8 @@
           <target state="new">Save</target>
         </trans-unit>
         <trans-unit id="ClassicFileSaveAs.Text" translate="yes" xml:space="preserve">
-          <source>Save as...</source>
-          <target state="new">Save as...</target>
+          <source>Save As...</source>
+          <target state="new">Save As...</target>
         </trans-unit>
         <trans-unit id="ClassicFileShare.Text" translate="yes" xml:space="preserve">
           <source>Share</source>
@@ -685,6 +685,10 @@
         <trans-unit id="StatusSelCount.Text" translate="yes" xml:space="preserve">
           <source>Selection: </source>
           <target state="new">Selection: </target>
+        </trans-unit>
+        <trans-unit id="GeneralShowStatusOnClassic.Text" translate="yes" xml:space="preserve">
+          <source>Show Status Bar on Classic Mode</source>
+          <target state="new">Show Status Bar on Classic Mode</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -559,8 +559,9 @@
           <target state="translated" state-qualifier="tm-suggestion">บันทึก</target>
         </trans-unit>
         <trans-unit id="ClassicFileSaveAs.Text" translate="yes" xml:space="preserve">
-          <source>Save as...</source>
-          <target state="translated">บันทึกเป็น</target>
+          <source>Save As...</source>
+          <target state="needs-review-translation">บันทึกเป็น</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="ClassicFileShare.Text" translate="yes" xml:space="preserve">
           <source>Share</source>
@@ -685,6 +686,10 @@
         <trans-unit id="StatusSelCount.Text" translate="yes" xml:space="preserve">
           <source>Selection: </source>
           <target state="translated">เลือก: </target>
+        </trans-unit>
+        <trans-unit id="GeneralShowStatusOnClassic.Text" translate="yes" xml:space="preserve">
+          <source>Show Status Bar on Classic Mode</source>
+          <target state="translated">แสดงแถบสถานะเมื่ออยู่ในโหมดคลาสสิค</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -170,7 +170,7 @@ namespace QuickPad
             set => Set(value);
         }
 
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool ShowStatusBar
         {
             get => Get<bool>();

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -532,7 +532,7 @@
     <value>Save</value>
   </data>
   <data name="ClassicFileSaveAs.Text" xml:space="preserve">
-    <value>Save as...</value>
+    <value>Save As...</value>
   </data>
   <data name="ClassicFileShare.Text" xml:space="preserve">
     <value>Share</value>
@@ -626,5 +626,8 @@
   </data>
   <data name="StatusSelCount.Text" xml:space="preserve">
     <value>Selection: </value>
+  </data>
+  <data name="GeneralShowStatusOnClassic.Text" xml:space="preserve">
+    <value>Show Status Bar on Classic Mode</value>
   </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -522,4 +522,7 @@
   <data name="StatusSelCount.Text" xml:space="preserve">
     <value>เลือก: </value>
   </data>
+  <data name="GeneralShowStatusOnClassic.Text" xml:space="preserve">
+    <value>แสดงแถบสถานะเมื่ออยู่ในโหมดคลาสสิค</value>
+  </data>
 </root>


### PR DESCRIPTION
### Visual fixes
- Fix Status Bar overlap the TextBox
- Change the Save icon from Symbol to FontIcon which can be changing size (As requested to scale it down - just a lil' bit)
- Fixed the size of Save Icon so it should not push Line/Cursor position tracking

### Back-end fix
- Status Bar should now turn on by default for new user
- Line/Cursor tracking should now show the current instead of total

### Other
- Adding tracker to track when TextBox is Tapped (Click/Tap/Press etc.) [Tapped]
- Adding tracker to track when TextBox is Pressing any key down [KeyDown]
- Moving "Status Bar" setting on General setting to below "Spell Check" and making it show all the time; this should address issue #51 
- Fix app setting font color to white instead of black on Light theme default color; this should address issue #52 
- A temporal fix for #50 - read a small statement on commit pls