### PR TITLE
A few fixes and improvement to Find and Replace

### DIFF
--- a/Quick Pad/Dialog/FindAndReplace.xaml
+++ b/Quick Pad/Dialog/FindAndReplace.xaml
@@ -40,10 +40,10 @@
             <ToggleButton IsChecked="{x:Bind ShowReplace, Mode=TwoWay}" Windows10version1809:CornerRadius="2">
                 <FontIcon Glyph="&#xE011;" />
                 <ToolTipService.ToolTip>
-                    <TextBlock Text="More..."/>
+                    <TextBlock Text="More..." x:Uid="FAR_More"/>
                 </ToolTipService.ToolTip>
             </ToggleButton>
-            <TextBox x:Name="FindInput" x:FieldModifier="public" Windows10version1809:CornerRadius="2" Text="{x:Bind TextToFind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" BorderThickness="1" Grid.Column="1" Margin="5,0" PlaceholderText="Looking for?"/>
+            <TextBox x:Uid="FAR_InputEmpty" x:Name="FindInput" x:FieldModifier="public" Windows10version1809:CornerRadius="2" Text="{x:Bind TextToFind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" BorderThickness="1" Grid.Column="1" Margin="5,0" PlaceholderText="Looking for?"/>
             <StackPanel Grid.Column="2" Orientation="Horizontal">
                 <Button Height="32" Click="{x:Bind SendRequestFind}" Windows10version1809:CornerRadius="2,0,0,2">
                     <Grid>
@@ -52,17 +52,17 @@
                         <FontIcon Glyph="&#xE0AB;" FontSize="8" VerticalAlignment="Bottom" HorizontalAlignment="Right" Visibility="{x:Bind q:Converter.BoolToVisibility(FindForward), Mode=OneWay}"/>
                     </Grid>
                     <ToolTipService.ToolTip>
-                        <TextBlock Text="Find"/>
+                        <TextBlock Text="Find" x:Uid="ClassicEditFind"/>
                     </ToolTipService.ToolTip>
                 </Button>
                 <Button Padding="2" Height="32" Windows10version1809:CornerRadius="0,2,2,0">
                     <FontIcon Glyph="&#xE813;"/>
                     <ToolTipService.ToolTip>
-                        <TextBlock Text="Find option"/>
+                        <TextBlock Text="Find option" x:Uid="FAR_FindOption"/>
                     </ToolTipService.ToolTip>
                     <Button.Flyout>
                         <MenuFlyout Placement="BottomEdgeAlignedRight">
-                            <MenuFlyoutItem Text="Find Next" Click="{x:Bind RequestFindNext}">
+                            <MenuFlyoutItem Text="Find Next" x:Uid="ClassicEditFindNext" Click="{x:Bind RequestFindNext}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE0AB;" />
                                 </MenuFlyoutItem.Icon>
@@ -70,7 +70,7 @@
                                     <KeyboardAccelerator Key="F3" />
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Text="Find Previous" Click="{x:Bind RequestFindPrevious}">
+                            <MenuFlyoutItem Text="Find Previous" x:Uid="ClassicEditFindPrevious" Click="{x:Bind RequestFindPrevious}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE0A6;" />
                                 </MenuFlyoutItem.Icon>
@@ -86,7 +86,7 @@
                 <Button Margin="5,0,0,0" Click="{x:Bind RequestCloseDialog}" Windows10version1809:CornerRadius="2">
                     <FontIcon Glyph="&#xE10A;" />
                     <ToolTipService.ToolTip>
-                        <TextBlock Text="Close"/>
+                        <TextBlock Text="Close" x:Uid="FAR_CloseDialog"/>
                     </ToolTipService.ToolTip>
                 </Button>
             </StackPanel>
@@ -97,22 +97,22 @@
                 <Button Click="{x:Bind SendRequestReplace}" Windows10version1809:CornerRadius="2">
                     <FontIcon Glyph="&#xE8AC;"/>
                     <ToolTipService.ToolTip>
-                        <TextBlock Text="Replace"/>
+                        <TextBlock Text="Replace" x:Uid="ClassicEditReplace"/>
                     </ToolTipService.ToolTip>
                 </Button>
 
                 <Button Margin="5,0" Click="{x:Bind SendRequestReplaceAll}" Windows10version1809:CornerRadius="2">
                     <FontIcon Glyph="&#xE8B3;"/>
                     <ToolTipService.ToolTip>
-                        <TextBlock Text="Replace all"/>
+                        <TextBlock Text="Replace all" x:Uid="FAR_ReplaceAll"/>
                     </ToolTipService.ToolTip>
                 </Button>
             </StackPanel>
             
             <!--Options-->
             <StackPanel Grid.Row="2" Grid.ColumnSpan="3" Visibility="{x:Bind q:Converter.BoolToVisibility(ShowReplace), Mode=OneWay}">
-                <CheckBox Content="Match case" IsChecked="{x:Bind MatchCase, Mode=TwoWay}"/>
-                <CheckBox Content="Wrap around" IsChecked="{x:Bind WrapAround, Mode=TwoWay}"/>
+                <CheckBox x:Uid="FAR_MatchCase" Content="Match case" IsChecked="{x:Bind MatchCase, Mode=TwoWay}"/>
+                <CheckBox x:Uid="FAR_WrapAround" Content="Wrap around" IsChecked="{x:Bind WrapAround, Mode=TwoWay}"/>
             </StackPanel>
         </Grid>
     </tkui:DropShadowPanel>

--- a/Quick Pad/Dialog/FindAndReplace.xaml
+++ b/Quick Pad/Dialog/FindAndReplace.xaml
@@ -92,7 +92,7 @@
             </StackPanel>
             
             <!--Second row-->
-            <TextBox Text="{x:Bind TextToReplace, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Windows10version1809:CornerRadius="2" BorderThickness="1" Grid.Column="1" Grid.Row="1" Margin="5" PlaceholderText="Replace with.." Visibility="{x:Bind q:Converter.BoolToVisibility(ShowReplace), Mode=OneWay}"/>
+            <TextBox x:Uid="FAR_ReplaceInput" Text="{x:Bind TextToReplace, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Windows10version1809:CornerRadius="2" BorderThickness="1" Grid.Column="1" Grid.Row="1" Margin="5" PlaceholderText="Replace with.." Visibility="{x:Bind q:Converter.BoolToVisibility(ShowReplace), Mode=OneWay}"/>
             <StackPanel Grid.Column="2" Grid.Row="1" Orientation="Horizontal" Visibility="{x:Bind q:Converter.BoolToVisibility(ShowReplace), Mode=OneWay}">
                 <Button Click="{x:Bind SendRequestReplace}" Windows10version1809:CornerRadius="2">
                     <FontIcon Glyph="&#xE8AC;"/>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -310,7 +310,7 @@
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem x:Uid="ClassicEditFind" Text="Find" Icon="Find" Click="{x:Bind FindAndReplaceDialog.SendRequestFind}">
+                <MenuFlyoutItem x:Uid="ClassicEditFind" Text="Find" Icon="Find" Click="{x:Bind ToggleFindAndReplaceDialog}">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator
                           Modifiers="Control" 

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -309,7 +309,22 @@
                         <SymbolIcon Symbol="Paste"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Delete" Click="Delete_Click" AccessKey="P" x:Uid="ClassicEditPaste">
+                    <MenuFlyoutItem.Icon>
+                        <SymbolIcon Symbol="Delete"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="Search with Bing..." Click="{x:Bind FindWithBing}">
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE12B;" />
+                    </MenuFlyoutItem.Icon>
+                    <MenuFlyoutItem.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                          Modifiers="Control" 
+                           Key="F" />
+                    </MenuFlyoutItem.KeyboardAccelerators>
+                </MenuFlyoutItem>
                 <MenuFlyoutItem x:Uid="ClassicEditFind" Text="Find" Icon="Find" Click="{x:Bind ToggleFindAndReplaceDialog}">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator
@@ -337,6 +352,25 @@
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Modifiers="Control" Key="H" />
                     </MenuFlyoutItem.KeyboardAccelerators>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Go To">
+                    <MenuFlyoutItem.KeyboardAccelerators>
+                        <KeyboardAccelerator Modifiers="Control" Key="H" />
+                    </MenuFlyoutItem.KeyboardAccelerators>
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE12F;" />
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="Select All">
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE8B3;" />
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Date/Time">
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xEC92;" />
+                    </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </winui:MenuBarItem>
             <winui:MenuBarItem Title="Format" AccessKey="O" x:Uid="ClassicFormat">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -309,6 +309,35 @@
                         <SymbolIcon Symbol="Paste"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="Find" Icon="Find" Click="{x:Bind FindAndReplaceDialog.SendRequestFind}">
+                    <MenuFlyoutItem.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                          Modifiers="Control" 
+                           Key="F" />
+                    </MenuFlyoutItem.KeyboardAccelerators>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Find Next" Click="{x:Bind FindAndReplaceDialog.RequestFindNext}">
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE0AB;" />
+                    </MenuFlyoutItem.Icon>
+                    <MenuFlyoutItem.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="F3" />
+                    </MenuFlyoutItem.KeyboardAccelerators>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Find Previous" Click="{x:Bind FindAndReplaceDialog.RequestFindPrevious}">
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE0A6;" />
+                    </MenuFlyoutItem.Icon>
+                    <MenuFlyoutItem.KeyboardAccelerators>
+                        <KeyboardAccelerator Modifiers="Shift" Key="F3" />
+                    </MenuFlyoutItem.KeyboardAccelerators>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Replace" Icon="Rename" Click="{x:Bind OpenFindDialogWithReplace}">
+                    <MenuFlyoutItem.KeyboardAccelerators>
+                        <KeyboardAccelerator Modifiers="Control" Key="H" />
+                    </MenuFlyoutItem.KeyboardAccelerators>
+                </MenuFlyoutItem>
             </winui:MenuBarItem>
             <winui:MenuBarItem Title="Format" AccessKey="O" x:Uid="ClassicFormat">
                 <ToggleMenuFlyoutItem Text="Word Wrap" IsChecked="{x:Bind QSetting.WordWrap, Mode=TwoWay}" x:Uid="WordWrap">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -310,14 +310,14 @@
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Find" Icon="Find" Click="{x:Bind FindAndReplaceDialog.SendRequestFind}">
+                <MenuFlyoutItem x:Uid="ClassicEditFind" Text="Find" Icon="Find" Click="{x:Bind FindAndReplaceDialog.SendRequestFind}">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator
                           Modifiers="Control" 
                            Key="F" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Find Next" Click="{x:Bind FindAndReplaceDialog.RequestFindNext}">
+                <MenuFlyoutItem x:Uid="ClassicEditFindNext" Text="Find Next" Click="{x:Bind FindAndReplaceDialog.RequestFindNext}">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE0AB;" />
                     </MenuFlyoutItem.Icon>
@@ -325,7 +325,7 @@
                         <KeyboardAccelerator Key="F3" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Find Previous" Click="{x:Bind FindAndReplaceDialog.RequestFindPrevious}">
+                <MenuFlyoutItem x:Uid="ClassicEditFindPrevious" Text="Find Previous" Click="{x:Bind FindAndReplaceDialog.RequestFindPrevious}">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE0A6;" />
                     </MenuFlyoutItem.Icon>
@@ -333,7 +333,7 @@
                         <KeyboardAccelerator Modifiers="Shift" Key="F3" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Text="Replace" Icon="Rename" Click="{x:Bind OpenFindDialogWithReplace}">
+                <MenuFlyoutItem x:Uid="ClassicEditReplace" Text="Replace" Icon="Rename" Click="{x:Bind OpenFindDialogWithReplace}">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Modifiers="Control" Key="H" />
                     </MenuFlyoutItem.KeyboardAccelerators>
@@ -445,8 +445,6 @@
         </winui:MenuBar>
 
         <dialog:FindAndReplace Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="10" Visibility="{x:Bind q:Converter.BoolToVisibility(ShowFindAndReplace), Mode=OneWay}" Canvas.ZIndex="90" x:Name="FindAndReplaceDialog"/>
-
-
 
         <RichEditBox Grid.Row="2" 
                      x:Name="Text1" 

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -169,7 +169,7 @@
                         <TextBlock Text="Share the file you are working on." x:Uid="CmdShareTooltip"/>
                     </ToolTipService.ToolTip>
                 </AppBarButton>
-                <AppBarButton Icon="Find" x:Uid="CmdFind" Width="Auto" MinWidth="40" Click="{x:Bind ToggleFindAndReplaceDialog}">
+                <AppBarButton Icon="Find" x:Uid="CmdFind" Width="Auto" MinWidth="40" Click="{x:Bind ToggleFindAndReplaceDialog}" Visibility="{x:Bind q:Converter.BoolToVisibilityInvert(CompactOverlaySwitch), Mode=OneWay}">
                     <AppBarButton.KeyboardAccelerators>
                         <KeyboardAccelerator
                           Modifiers="Control" 
@@ -416,6 +416,8 @@
         </winui:MenuBar>
 
         <dialog:FindAndReplace Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="10" Visibility="{x:Bind q:Converter.BoolToVisibility(ShowFindAndReplace), Mode=OneWay}" Canvas.ZIndex="90" x:Name="FindAndReplaceDialog"/>
+
+
 
         <RichEditBox Grid.Row="2" 
                      x:Name="Text1" 

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1357,6 +1357,9 @@ namespace QuickPad
                     Text1.FontSize = 16;
                 }
 
+                //Hide Find and Replace dialog if it open
+                ShowFindAndReplace = false;
+
                 //log even in app center
                 Analytics.TrackEvent("Compact Overlay");
             }

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1024,6 +1024,8 @@ namespace QuickPad
             Text1.Document.EndUndoGroup();
         }
 
+        private void Delete_Click(object sender, RoutedEventArgs e) => Text1.TextDocument.Selection.Text = string.Empty;
+
         private async void Paste_Click(object sender, RoutedEventArgs e)
         {
             DataPackageView dataPackageView = Clipboard.GetContent();
@@ -1779,6 +1781,14 @@ namespace QuickPad
         {
             get => _maxRange;
             set => Set(ref _maxRange, value);
+        }
+
+        private async void FindWithBing()
+        {
+            if (Text1.TextDocument.Selection.Text.Length > 0)
+            {
+                await Windows.System.Launcher.LaunchUriAsync(new Uri($"https://www.bing.com/search?q={Text1.TextDocument.Selection.Text}"));
+            }
         }
 
         private void FindRequestedText(string find, bool direction, bool match, bool wrap)

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1730,11 +1730,13 @@ namespace QuickPad
                     {
                         if (Text1.Document.Selection.Length > 1)
                         {
-                            if (string.IsNullOrEmpty(FindAndReplaceDialog.TextToFind))
-                            {
-                                FindAndReplaceDialog.TextToFind = Text1.Document.Selection.Text;
-                                FindAndReplaceDialog.FindInput.Focus(FocusState.Keyboard);
-                            }
+                            FindAndReplaceDialog.TextToFind = Text1.Document.Selection.Text;
+                            DelayFocus();
+                        }
+                        else
+                        {
+                            FindAndReplaceDialog.TextToFind = "";
+                            DelayFocus();
                         }
                         FindAndReplaceDialog.onRequestFinding += FindRequestedText;
                         FindAndReplaceDialog.onRequestReplacing += FindAndReplaceRequestedText;
@@ -1748,6 +1750,13 @@ namespace QuickPad
                     }
                 }
             }
+        }
+
+        async void DelayFocus()
+        {
+            await Task.Delay(100);
+            FindAndReplaceDialog.FindInput.Focus(FocusState.Keyboard);
+            FindAndReplaceDialog.FindInput.SelectionStart = FindAndReplaceDialog.FindInput.Text.Length;
         }
 
         public void ToggleFindAndReplaceDialog()

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1771,6 +1771,11 @@ namespace QuickPad
 
         private void FindRequestedText(string find, bool direction, bool match, bool wrap)
         {
+            if (string.IsNullOrEmpty(find))
+            {
+                //Nothing to search for
+                return;
+            }
             if (direction)
             {
                 StartSearchPosition = Text1.TextDocument.Selection.FindText(find, MaximumPossibleSearchRange, match ? FindOptions.Case : FindOptions.None);
@@ -1810,6 +1815,15 @@ namespace QuickPad
 
         private void FindAndReplaceRequestedText(string find, string replace, bool direction, bool match, bool wrap, bool all)
         {
+            if (string.IsNullOrEmpty(find))
+            {
+                //Nothing to search for
+                return;
+            }
+            if (replace is null)
+            {
+                replace = string.Empty;
+            }
             if (all)
             {
                 //Replace all

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1875,6 +1875,12 @@ namespace QuickPad
             }
         }
 
+        //Menubar function
+        public void OpenFindDialogWithReplace()
+        {
+            FindAndReplaceDialog.ShowReplace = true;
+            ShowFindAndReplace = true;
+        }
         #endregion
     }
 

--- a/Quick Pad/MultilingualResources/Quick Pad.ar-SA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.ar-SA.xlf
@@ -702,6 +702,54 @@
           <source>Find</source>
           <target state="new">Find</target>
         </trans-unit>
+        <trans-unit id="ClassicEditFind.Text" translate="yes" xml:space="preserve">
+          <source>Find</source>
+          <target state="new">Find</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFindNext.Text" translate="yes" xml:space="preserve">
+          <source>Find Next</source>
+          <target state="new">Find Next</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFindPrevious.Text" translate="yes" xml:space="preserve">
+          <source>Find Previous</source>
+          <target state="new">Find Previous</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditReplace.Text" translate="yes" xml:space="preserve">
+          <source>Replace</source>
+          <target state="new">Replace</target>
+        </trans-unit>
+        <trans-unit id="FAR_CloseDialog.Text" translate="yes" xml:space="preserve">
+          <source>Close</source>
+          <target state="new">Close</target>
+        </trans-unit>
+        <trans-unit id="FAR_FindOption.Text" translate="yes" xml:space="preserve">
+          <source>Find option</source>
+          <target state="new">Find option</target>
+        </trans-unit>
+        <trans-unit id="FAR_InputEmpty.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Looking for?</source>
+          <target state="new">Looking for?</target>
+        </trans-unit>
+        <trans-unit id="FAR_MatchCase.Content" translate="yes" xml:space="preserve">
+          <source>Match case</source>
+          <target state="new">Match case</target>
+        </trans-unit>
+        <trans-unit id="FAR_More.Text" translate="yes" xml:space="preserve">
+          <source>More...</source>
+          <target state="new">More...</target>
+        </trans-unit>
+        <trans-unit id="FAR_ReplaceAll.Text" translate="yes" xml:space="preserve">
+          <source>Replace All</source>
+          <target state="new">Replace All</target>
+        </trans-unit>
+        <trans-unit id="FAR_WrapAround.Content" translate="yes" xml:space="preserve">
+          <source>Wrap around</source>
+          <target state="new">Wrap around</target>
+        </trans-unit>
+        <trans-unit id="FAR_ReplaceInput.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Replace with..</source>
+          <target state="new">Replace with..</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.es.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.es.xlf
@@ -702,6 +702,54 @@
           <source>Find</source>
           <target state="new">Find</target>
         </trans-unit>
+        <trans-unit id="ClassicEditFind.Text" translate="yes" xml:space="preserve">
+          <source>Find</source>
+          <target state="new">Find</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFindNext.Text" translate="yes" xml:space="preserve">
+          <source>Find Next</source>
+          <target state="new">Find Next</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFindPrevious.Text" translate="yes" xml:space="preserve">
+          <source>Find Previous</source>
+          <target state="new">Find Previous</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditReplace.Text" translate="yes" xml:space="preserve">
+          <source>Replace</source>
+          <target state="new">Replace</target>
+        </trans-unit>
+        <trans-unit id="FAR_CloseDialog.Text" translate="yes" xml:space="preserve">
+          <source>Close</source>
+          <target state="new">Close</target>
+        </trans-unit>
+        <trans-unit id="FAR_FindOption.Text" translate="yes" xml:space="preserve">
+          <source>Find option</source>
+          <target state="new">Find option</target>
+        </trans-unit>
+        <trans-unit id="FAR_InputEmpty.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Looking for?</source>
+          <target state="new">Looking for?</target>
+        </trans-unit>
+        <trans-unit id="FAR_MatchCase.Content" translate="yes" xml:space="preserve">
+          <source>Match case</source>
+          <target state="new">Match case</target>
+        </trans-unit>
+        <trans-unit id="FAR_More.Text" translate="yes" xml:space="preserve">
+          <source>More...</source>
+          <target state="new">More...</target>
+        </trans-unit>
+        <trans-unit id="FAR_ReplaceAll.Text" translate="yes" xml:space="preserve">
+          <source>Replace All</source>
+          <target state="new">Replace All</target>
+        </trans-unit>
+        <trans-unit id="FAR_WrapAround.Content" translate="yes" xml:space="preserve">
+          <source>Wrap around</source>
+          <target state="new">Wrap around</target>
+        </trans-unit>
+        <trans-unit id="FAR_ReplaceInput.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Replace with..</source>
+          <target state="new">Replace with..</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
@@ -702,6 +702,54 @@
           <source>Find</source>
           <target state="new">Find</target>
         </trans-unit>
+        <trans-unit id="ClassicEditFind.Text" translate="yes" xml:space="preserve">
+          <source>Find</source>
+          <target state="new">Find</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFindNext.Text" translate="yes" xml:space="preserve">
+          <source>Find Next</source>
+          <target state="new">Find Next</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFindPrevious.Text" translate="yes" xml:space="preserve">
+          <source>Find Previous</source>
+          <target state="new">Find Previous</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditReplace.Text" translate="yes" xml:space="preserve">
+          <source>Replace</source>
+          <target state="new">Replace</target>
+        </trans-unit>
+        <trans-unit id="FAR_CloseDialog.Text" translate="yes" xml:space="preserve">
+          <source>Close</source>
+          <target state="new">Close</target>
+        </trans-unit>
+        <trans-unit id="FAR_FindOption.Text" translate="yes" xml:space="preserve">
+          <source>Find option</source>
+          <target state="new">Find option</target>
+        </trans-unit>
+        <trans-unit id="FAR_InputEmpty.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Looking for?</source>
+          <target state="new">Looking for?</target>
+        </trans-unit>
+        <trans-unit id="FAR_MatchCase.Content" translate="yes" xml:space="preserve">
+          <source>Match case</source>
+          <target state="new">Match case</target>
+        </trans-unit>
+        <trans-unit id="FAR_More.Text" translate="yes" xml:space="preserve">
+          <source>More...</source>
+          <target state="new">More...</target>
+        </trans-unit>
+        <trans-unit id="FAR_ReplaceAll.Text" translate="yes" xml:space="preserve">
+          <source>Replace All</source>
+          <target state="new">Replace All</target>
+        </trans-unit>
+        <trans-unit id="FAR_WrapAround.Content" translate="yes" xml:space="preserve">
+          <source>Wrap around</source>
+          <target state="new">Wrap around</target>
+        </trans-unit>
+        <trans-unit id="FAR_ReplaceInput.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Replace with..</source>
+          <target state="new">Replace with..</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -560,8 +560,7 @@
         </trans-unit>
         <trans-unit id="ClassicFileSaveAs.Text" translate="yes" xml:space="preserve">
           <source>Save As...</source>
-          <target state="needs-review-translation">บันทึกเป็น</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">บันทึกเป็น</target>
         </trans-unit>
         <trans-unit id="ClassicFileShare.Text" translate="yes" xml:space="preserve">
           <source>Share</source>
@@ -693,15 +692,63 @@
         </trans-unit>
         <trans-unit id="AppLanguage.Text" translate="yes" xml:space="preserve">
           <source>App Language</source>
-          <target state="new">App Language</target>
+          <target state="translated">ภาษา</target>
         </trans-unit>
         <trans-unit id="CmdOnTopTooltip" translate="yes" xml:space="preserve">
           <source>On Top (Ctrl+Shift+O)</source>
-          <target state="new">On Top (Ctrl+Shift+O)</target>
+          <target state="translated">ทับแอปอื่น (Ctrl+Shift+O)</target>
         </trans-unit>
         <trans-unit id="CmdFind.Label" translate="yes" xml:space="preserve">
           <source>Find</source>
-          <target state="new">Find</target>
+          <target state="translated" state-qualifier="tm-suggestion">ค้นหา</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFind.Text" translate="yes" xml:space="preserve">
+          <source>Find</source>
+          <target state="translated" state-qualifier="tm-suggestion">ค้นหา</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFindNext.Text" translate="yes" xml:space="preserve">
+          <source>Find Next</source>
+          <target state="translated" state-qualifier="tm-suggestion">ค้นหาถัดไป</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditFindPrevious.Text" translate="yes" xml:space="preserve">
+          <source>Find Previous</source>
+          <target state="translated" state-qualifier="tm-suggestion">ค้นหาก่อนหน้า</target>
+        </trans-unit>
+        <trans-unit id="ClassicEditReplace.Text" translate="yes" xml:space="preserve">
+          <source>Replace</source>
+          <target state="translated">แทนที่</target>
+        </trans-unit>
+        <trans-unit id="FAR_CloseDialog.Text" translate="yes" xml:space="preserve">
+          <source>Close</source>
+          <target state="translated" state-qualifier="tm-suggestion">ปิด</target>
+        </trans-unit>
+        <trans-unit id="FAR_FindOption.Text" translate="yes" xml:space="preserve">
+          <source>Find option</source>
+          <target state="translated">ตัวเลือกการหา</target>
+        </trans-unit>
+        <trans-unit id="FAR_InputEmpty.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Looking for?</source>
+          <target state="translated">ต้องการหาอะไร พิมพ์เลย!</target>
+        </trans-unit>
+        <trans-unit id="FAR_MatchCase.Content" translate="yes" xml:space="preserve">
+          <source>Match case</source>
+          <target state="translated" state-qualifier="tm-suggestion">ตรงตามตัวพิมพ์ใหญ่-เล็ก</target>
+        </trans-unit>
+        <trans-unit id="FAR_More.Text" translate="yes" xml:space="preserve">
+          <source>More...</source>
+          <target state="translated" state-qualifier="tm-suggestion">เพิ่มเติม</target>
+        </trans-unit>
+        <trans-unit id="FAR_ReplaceAll.Text" translate="yes" xml:space="preserve">
+          <source>Replace All</source>
+          <target state="translated" state-qualifier="tm-suggestion">แทนที่ทั้งหมด</target>
+        </trans-unit>
+        <trans-unit id="FAR_WrapAround.Content" translate="yes" xml:space="preserve">
+          <source>Wrap around</source>
+          <target state="translated">ค้นหาแบบวน</target>
+        </trans-unit>
+        <trans-unit id="FAR_ReplaceInput.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Replace with..</source>
+          <target state="translated">แทนที่ด้วย..</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -639,4 +639,37 @@
   <data name="CmdFind.Label" xml:space="preserve">
     <value>Find</value>
   </data>
+  <data name="ClassicEditFind.Text" xml:space="preserve">
+    <value>Find</value>
+  </data>
+  <data name="ClassicEditFindNext.Text" xml:space="preserve">
+    <value>Find Next</value>
+  </data>
+  <data name="ClassicEditFindPrevious.Text" xml:space="preserve">
+    <value>Find Previous</value>
+  </data>
+  <data name="ClassicEditReplace.Text" xml:space="preserve">
+    <value>Replace</value>
+  </data>
+  <data name="FAR_CloseDialog.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="FAR_FindOption.Text" xml:space="preserve">
+    <value>Find option</value>
+  </data>
+  <data name="FAR_InputEmpty.PlaceholderText" xml:space="preserve">
+    <value>Looking for?</value>
+  </data>
+  <data name="FAR_MatchCase.Content" xml:space="preserve">
+    <value>Match case</value>
+  </data>
+  <data name="FAR_More.Text" xml:space="preserve">
+    <value>More...</value>
+  </data>
+  <data name="FAR_ReplaceAll.Text" xml:space="preserve">
+    <value>Replace All</value>
+  </data>
+  <data name="FAR_WrapAround.Content" xml:space="preserve">
+    <value>Wrap around</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -672,4 +672,7 @@
   <data name="FAR_WrapAround.Content" xml:space="preserve">
     <value>Wrap around</value>
   </data>
+  <data name="FAR_ReplaceInput.PlaceholderText" xml:space="preserve">
+    <value>Replace with..</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -525,4 +525,49 @@
   <data name="GeneralShowStatusOnClassic.Text" xml:space="preserve">
     <value>แสดงแถบสถานะเมื่ออยู่ในโหมดคลาสสิค</value>
   </data>
+  <data name="AppLanguage.Text" xml:space="preserve">
+    <value>ภาษา</value>
+  </data>
+  <data name="CmdOnTopTooltip" xml:space="preserve">
+    <value>ทับแอปอื่น (Ctrl+Shift+O)</value>
+  </data>
+  <data name="CmdFind.Label" xml:space="preserve">
+    <value>ค้นหา</value>
+  </data>
+  <data name="ClassicEditFind.Text" xml:space="preserve">
+    <value>ค้นหา</value>
+  </data>
+  <data name="ClassicEditFindNext.Text" xml:space="preserve">
+    <value>ค้นหาถัดไป</value>
+  </data>
+  <data name="ClassicEditFindPrevious.Text" xml:space="preserve">
+    <value>ค้นหาก่อนหน้า</value>
+  </data>
+  <data name="ClassicEditReplace.Text" xml:space="preserve">
+    <value>แทนที่</value>
+  </data>
+  <data name="FAR_CloseDialog.Text" xml:space="preserve">
+    <value>ปิด</value>
+  </data>
+  <data name="FAR_FindOption.Text" xml:space="preserve">
+    <value>ตัวเลือกการหา</value>
+  </data>
+  <data name="FAR_InputEmpty.PlaceholderText" xml:space="preserve">
+    <value>ต้องการหาอะไร พิมพ์เลย!</value>
+  </data>
+  <data name="FAR_MatchCase.Content" xml:space="preserve">
+    <value>ตรงตามตัวพิมพ์ใหญ่-เล็ก</value>
+  </data>
+  <data name="FAR_More.Text" xml:space="preserve">
+    <value>เพิ่มเติม</value>
+  </data>
+  <data name="FAR_ReplaceAll.Text" xml:space="preserve">
+    <value>แทนที่ทั้งหมด</value>
+  </data>
+  <data name="FAR_WrapAround.Content" xml:space="preserve">
+    <value>ค้นหาแบบวน</value>
+  </data>
+  <data name="FAR_ReplaceInput.PlaceholderText" xml:space="preserve">
+    <value>แทนที่ด้วย..</value>
+  </data>
 </root>


### PR DESCRIPTION
- Fix app crash from searching nothing
- Hide a button from compact overlay mode and if the dialog is open it will close upon entering that mode
- Focus Find input when open the dialog
- Add dialog into classic menu