### PR TITLE
By default, customize toolbar will close when click any item on toolbar

### DIFF
--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -155,7 +155,7 @@
                 </ToolTipService.ToolTip>
             </AppBarButton>
             <AppBarSeparator Width="32" Visibility="{x:Bind q:Converter.HideIfNoSizeButtonShow(QSetting.ShowSizeUp, QSetting.ShowSizeDown), Mode=OneWay}"/>
-            <AppBarButton Label="Customize" Width="Auto" MinWidth="32" Click="{x:Bind OpenCustomizeFlyout}" LabelPosition="Default">
+            <AppBarButton Label="Customize" Width="Auto" MinWidth="32" LabelPosition="Default">
                 <AppBarButton.Icon>
                     <FontIcon Glyph="&#xE15E;" />
                 </AppBarButton.Icon>
@@ -187,11 +187,6 @@
                         <ToggleMenuFlyoutItem Text="Show size down" Icon="FontDecrease" IsChecked="{x:Bind QSetting.ShowSizeDown, Mode=TwoWay}"/>
                         <MenuFlyoutSeparator/>
                         <MenuFlyoutItem Text="Reset toolbar" Icon="Sync" Click="{x:Bind ResetToolbarSetting}"/>
-                        <MenuFlyoutItem Text="Done" Click="{x:Bind OpenCustomizeFlyout}">
-                            <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE001;" />
-                            </MenuFlyoutItem.Icon>
-                        </MenuFlyoutItem>
                     </MenuFlyout>
                 </AppBarButton.Flyout>
             </AppBarButton>

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1347,22 +1347,10 @@ namespace QuickPad
             }
         }
 
-        bool _forceOpen;
-        public bool ForceFlyoutOpen
-        {
-            get => _forceOpen;
-            set => Set(ref _forceOpen, value);
-        }
-
         private void ClosingCustomizeFlyout(Windows.UI.Xaml.Controls.Primitives.FlyoutBase sender, Windows.UI.Xaml.Controls.Primitives.FlyoutBaseClosingEventArgs args)
         {
-            if (ForceFlyoutOpen)
+            if (Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down))
                 args.Cancel = true;
-        }
-
-        public void OpenCustomizeFlyout()
-        {
-            ForceFlyoutOpen = !ForceFlyoutOpen;
         }
 
         public void ResetToolbarSetting()


### PR DESCRIPTION
However, you can force it open by holding shift