### PR TITLE
Adding shortcut key for Focus mode

### DIFF
--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -776,6 +776,7 @@
 
         <Grid x:Name="Title" Canvas.ZIndex="100" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" VerticalAlignment="Top" Height="33" HorizontalAlignment="Stretch">
             <StackPanel Orientation="Horizontal">
+                <Button Width="48" Height="32" Foreground="Transparent" Background="Transparent" Visibility="{x:Bind FocusModeSwitch, Mode=OneWay}"/>
                 <TextBlock Text="{x:Bind CurrentFilename, Mode=OneWay}"
                            Style="{ThemeResource CaptionTextBlockStyle}"
                            VerticalAlignment="Center" Margin="10,0,0,0" FontSize="14"

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -194,8 +194,8 @@
 
         <CommandBar x:Name="CommandBar2" DefaultLabelPosition="Collapsed" Canvas.ZIndex="75" IsOpen="False" HorizontalAlignment="Right" Grid.Row="1" VerticalAlignment="Top" Height="40" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}">
             <CommandBar.SecondaryCommands>
-                <AppBarButton x:Name="CmdFocusMode" x:Uid="CmdFocusMode" Click="{x:Bind TurnOnFocusMode}" Icon="Caption" Label="Focus Mode" Width="Auto"/>
-                <AppBarButton x:Name="CmdClassicMode" Click="{x:Bind TurnOnClassicMode}" Label="Classic Mode" x:Uid="CmdClassicMode" Width="Auto">
+                <AppBarButton x:Name="CmdFocusMode" x:Uid="CmdFocusMode" Click="{x:Bind SwitchingFocusMode}" Icon="Caption" Label="Focus Mode" Width="Auto"/>
+                <AppBarButton x:Name="CmdClassicMode" Click="{x:Bind SwitchingClassicAndDefault}" Label="Classic Mode" x:Uid="CmdClassicMode" Width="Auto">
                     <AppBarButton.Icon>
                         <FontIcon Glyph="&#xE8C5;" />
                     </AppBarButton.Icon>
@@ -425,21 +425,21 @@
                 </MenuFlyoutItem>
             </winui:MenuBarItem>
             <winui:MenuBarItem Title="View" AccessKey="V" x:Uid="ClassicView">
-                <ToggleMenuFlyoutItem Text="Back to default mode" AccessKey="D" IsChecked="{x:Bind ClassicModeSwitch, Mode=TwoWay}" x:Uid="ClassicViewBack">
-                    <ToggleMenuFlyoutItem.Icon>
+                <MenuFlyoutItem Text="Back to default mode" AccessKey="D" Click="{x:Bind SwitchingClassicAndDefault}" x:Uid="ClassicViewBack">
+                    <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Back"/>
-                    </ToggleMenuFlyoutItem.Icon>
-                </ToggleMenuFlyoutItem>
-                <ToggleMenuFlyoutItem Text="Focus Mode" AccessKey="F" IsChecked="{x:Bind FocusModeSwitch, Mode=TwoWay}" x:Uid="ClassicViewFocus">
-                    <ToggleMenuFlyoutItem.Icon>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Focus Mode" AccessKey="F" Click="{x:Bind SwitchingFocusMode}" x:Uid="ClassicViewFocus">
+                    <MenuFlyoutItem.Icon>
                         <SymbolIcon Symbol="Caption"/>
-                    </ToggleMenuFlyoutItem.Icon>
-                </ToggleMenuFlyoutItem>
-                <ToggleMenuFlyoutItem Text="Overlay mode" AccessKey="O" IsChecked="{x:Bind CompactOverlaySwitch, Mode=TwoWay}" x:Uid="ClassicViewOverlay">
-                    <ToggleMenuFlyoutItem.Icon>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Overlay mode" AccessKey="O" Click="{x:Bind SwitchingOverlayMode}" x:Uid="ClassicViewOverlay">
+                    <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE158;" />
-                    </ToggleMenuFlyoutItem.Icon>
-                </ToggleMenuFlyoutItem>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
                 <MenuFlyoutSubItem Text="Zoom" x:Uid="ClassicZoom" AccessKey="Z">
                     <MenuFlyoutSubItem.Icon>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -776,7 +776,15 @@
 
         <Grid x:Name="Title" Canvas.ZIndex="100" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" VerticalAlignment="Top" Height="33" HorizontalAlignment="Stretch">
             <StackPanel Orientation="Horizontal">
-                <Button Width="48" Height="32" Foreground="Transparent" Background="Transparent" Visibility="{x:Bind FocusModeSwitch, Mode=OneWay}"/>
+                <Button Width="48" Height="32" Foreground="Transparent" Background="Transparent" Visibility="{x:Bind FocusModeSwitch, Mode=OneWay}" x:Name="BackButtonHolder">
+                    <Button.Resources>
+                        <winui:TeachingTip x:Name="HowToLeaveFocus"
+                                           Target="{x:Bind BackButtonHolder}"
+                                           Title="Leave focus mode button has been moved"
+                                           Subtitle="We've moved the button to here, so it would be more cleaner. You can also press Control + Shift + F to leave">
+                        </winui:TeachingTip>
+                    </Button.Resources>
+                </Button>
                 <TextBlock Text="{x:Bind CurrentFilename, Mode=OneWay}"
                            Style="{ThemeResource CaptionTextBlockStyle}"
                            VerticalAlignment="Center" Margin="10,0,0,0" FontSize="14"

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -39,12 +39,6 @@
             <Frame x:Name="FrameTop" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Visibility="Visible" VerticalAlignment="Top" Height="40" Grid.RowSpan="1"/>
         </controls:DropShadowPanel>
 
-        <ToggleButton x:Name="CloseFocusMode" IsChecked="{x:Bind FocusModeSwitch, Mode=TwoWay}" Visibility="{x:Bind q:Converter.BoolToVisibility(FocusModeSwitch), Mode=OneWay}" HorizontalAlignment="Right" Content="°°°" VerticalAlignment="Top" Margin="0,10,10,0" Canvas.ZIndex="1500" VerticalContentAlignment="Center" FontSize="10" Width="35" Height="20" Windows10version1809:CornerRadius="2" Grid.Row="2">
-            <ToolTipService.ToolTip>
-                <TextBlock Text="Exit focus mode" x:Uid="ExitFocusMode"/>
-            </ToolTipService.ToolTip>
-        </ToggleButton>
-
         <CommandBar x:Name="CommandBar1" DefaultLabelPosition="Collapsed" Canvas.ZIndex="75" IsOpen="False" HorizontalAlignment="Left" Grid.Row="1" VerticalAlignment="Top" Height="40" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Margin="0,0,340,0">
             <AppBarButton x:Name="CmdNew" x:Uid="CmdNew" Label="New" Width="Auto" MinWidth="40" Click="CmdNew_Click">
                 <ToolTipService.ToolTip>
@@ -787,6 +781,18 @@
                            VerticalAlignment="Center" Margin="10,0,0,0" FontSize="14"
                            Visibility="{x:Bind q:Converter.BoolToVisibilityInvert(CompactOverlaySwitch), Mode=OneWay}"/>
             </StackPanel>
+            <Button x:Name="InvisibleButton" 
+                    Width="0"
+                    Height="0" 
+                    BorderBrush="Transparent"
+                    BorderThickness="0"
+                    IsTabStop="False" 
+                    IsTapEnabled="False" 
+                    Foreground="Transparent" 
+                    Background="Transparent" 
+                    IsHitTestVisible="False"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Bottom"/>
         </Grid>
     </Grid>
 </Page>

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1510,6 +1510,8 @@ namespace QuickPad
                 Shadow1.Visibility = Visibility.Collapsed;
                 row1.Height = new GridLength(0);
                 row3.Height = new GridLength(0);
+                QSetting.TimesUsingFocusMode++;
+                HowToLeaveFocus.IsOpen = QSetting.TimesUsingFocusMode < 2;
             }
             else
             {
@@ -1526,6 +1528,8 @@ namespace QuickPad
                 {
                     ShowFindAndReplace = false;
                 }
+                if (HowToLeaveFocus.IsOpen)
+                    HowToLeaveFocus.IsOpen = false;
             }
             if (ClassicModeSwitch == true)
             {

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -1537,8 +1537,9 @@ namespace QuickPad
         }
 
         //Use for Click function
-        public void TurnOnFocusMode() => FocusModeSwitch = true;
-        public void TurnOnClassicMode() => ClassicModeSwitch = true;
+        public void SwitchingFocusMode() => FocusModeSwitch = !FocusModeSwitch;
+        public void SwitchingOverlayMode() => CompactOverlaySwitch = !CompactOverlaySwitch;
+        public void SwitchingClassicAndDefault() => ClassicModeSwitch = !ClassicModeSwitch;
         #endregion
 
         #region Textbox function

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -123,6 +123,15 @@ namespace QuickPad
                 }
             };
 
+            SystemNavigationManager.GetForCurrentView().BackRequested += (sender, e) =>
+            {
+                e.Handled = true;
+                if (FocusModeSwitch)
+                {
+                    FocusModeSwitch = false;
+                }
+            };
+
             //ask user if they want to save before closing the app
             Windows.UI.Core.Preview.SystemNavigationManagerPreview.GetForCurrentView().CloseRequested += async (sender, e) =>
             {
@@ -1493,6 +1502,7 @@ namespace QuickPad
         {
             if (switching)
             {
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
                 Text1.SetValue(Canvas.ZIndexProperty, 90);
                 CommandBar1.Visibility = Visibility.Collapsed;
                 CommandBar2.Visibility = Visibility.Collapsed;
@@ -1503,6 +1513,7 @@ namespace QuickPad
             }
             else
             {
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Disabled;
                 Text1.SetValue(Canvas.ZIndexProperty, 0);
                 CommandBar2.Visibility = Visibility.Visible;
                 CommandBar1.Visibility = Visibility.Visible;

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -103,18 +103,23 @@ namespace QuickPad
             {
                 if (args.WindowActivationState == Windows.UI.Core.CoreWindowActivationState.Deactivated)
                 {
-                    if (CommandBar2.Visibility == Visibility.Visible)
-                    {
-                        CommandBar2.Focus(FocusState.Programmatic); // Set focus off the main content
-                    }
-                    if (CloseFocusMode.Visibility == Visibility.Visible)
-                    {
-                        CloseFocusMode.Focus(FocusState.Programmatic); // Set focus off the main content
-                    }
-                    if (CommandBarClassic.Visibility == Visibility.Visible)
-                    {
-                        CommandBarClassic.Focus(FocusState.Programmatic); // Set focus off the main content
-                    }
+                    InvisibleButton.Focus(FocusState.Programmatic);
+                }
+            };
+
+            Window.Current.CoreWindow.KeyDown += (sender, args) =>
+            {
+                if (CompactOverlaySwitch)//Not allow to switch on focus mode
+                    return;
+                //CTRL
+                bool ctrl = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+                //SHIFT
+                bool shift = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+                //F
+                bool f = Window.Current.CoreWindow.GetKeyState(VirtualKey.F).HasFlag(CoreVirtualKeyStates.Down);
+                if (ctrl && shift && f)
+                {
+                    FocusModeSwitch = !FocusModeSwitch;
                 }
             };
 

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -365,6 +365,15 @@ namespace QuickPad
         }
         #endregion
 
+        #region
+        [DefaultValue(0)]
+        public int TimesUsingFocusMode 
+        { //Use to track focus mode, if less than 2 times it will show tip, else it won't
+            get => Get<int>();
+            set => Set(value);
+        }
+        #endregion
+
         #region Events when setting change
         public autoSaveChange afterAutoSaveChanged { get; set; }
         public themeChange afterThemeChanged { get; set; }


### PR DESCRIPTION
For issue #12 

- Adding shortcut key to switch on and off focus mode
(If you hold it, the app will keep on switch between focus mode D: )
- Remove leave focus mode button
- Show back button on focus mode
- Show teaching tip for 2 times when switching to it, so users know how to leave focus mode