### PR TITLE
Update Thai translation

### DIFF
--- a/Quick Pad/Dialog/FindAndReplace.xaml
+++ b/Quick Pad/Dialog/FindAndReplace.xaml
@@ -167,8 +167,8 @@
                         Orientation="Vertical"
                         Margin="4"
                         Visibility="{x:Bind q:Converter.BoolToVisibility(ShowReplace), Mode=OneWay}">
-                <CheckBox x:Uid="FAR_MatchCase" Content="Match case" IsChecked="{x:Bind MatchCase, Mode=TwoWay}" w10v1809:CornerRadius="{x:Bind q:Converter.IntToCorner(QSetting.GlobalButtonCorner), Mode=OneWay}"/>
-                <CheckBox x:Uid="FAR_WrapAround" Content="Wrap around" IsChecked="{x:Bind WrapAround, Mode=TwoWay}" w10v1809:CornerRadius="{x:Bind q:Converter.IntToCorner(QSetting.GlobalButtonCorner), Mode=OneWay}"/>
+                <CheckBox x:Uid="FAR_MatchCase" Content="Match case" IsChecked="{x:Bind MatchCase, Mode=TwoWay}"/>
+                <CheckBox x:Uid="FAR_WrapAround" Content="Wrap around" IsChecked="{x:Bind WrapAround, Mode=TwoWay}"/>
             </StackPanel>
             <!-- END OF Options -->
         </Grid>

--- a/Quick Pad/Dialog/GoTo.xaml
+++ b/Quick Pad/Dialog/GoTo.xaml
@@ -13,7 +13,6 @@
     RequestedTheme="{x:Bind VisualThemeSelector.CurrentItem.Theme, Mode=OneWay}"
     x:Uid="GT_Dialog"    
     Title="Go To Line"
-    w10v1809:CornerRadius="{x:Bind q:Converter.IntToCorner(QSetting.GlobalDialogCorner), Mode=OneWay}" 
     Opened="ContentDialog_Opened"    
     
     PrimaryButtonText="Go to"
@@ -43,7 +42,6 @@
                  extensions:TextBoxRegex.ValidationMode="Dynamic" 
                  extensions:TextBoxRegex.ValidationType="Number"
                  KeyDown="LineInput_KeyDown" 
-                 Style="{ThemeResource FluentTextBoxStyle}" 
-                 w10v1809:CornerRadius="{x:Bind q:Converter.IntToCorner(QSetting.GlobalButtonCorner), Mode=OneWay}"/>
+                 Style="{ThemeResource FluentTextBoxStyle}"/>
     </Grid>
 </ContentDialog>

--- a/Quick Pad/Dialog/SaveChange.xaml
+++ b/Quick Pad/Dialog/SaveChange.xaml
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:w10v1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     xmlns:q="using:QuickPad"
-    w10v1809:CornerRadius="{x:Bind q:Converter.IntToCorner(QSetting.GlobalDialogCorner), Mode=OneWay}"   
     Background="{x:Bind VisualThemeSelector.CurrentItem.BackgroundAcrylicBrush, Mode=OneWay}"
     RequestedTheme="{x:Bind VisualThemeSelector.CurrentItem.Theme, Mode=OneWay}"
     mc:Ignorable="d"

--- a/Quick Pad/Dialog/Settings.xaml
+++ b/Quick Pad/Dialog/Settings.xaml
@@ -206,19 +206,9 @@
 
                         <TextBlock x:Uid="ManageSettings" Text="Manage settings" FontSize="16"/>
                         <StackPanel Orientation="Horizontal">
-                            <Button w10v1809:CornerRadius="{x:Bind q:Converter.IntToCorner(QSetting.GlobalButtonCorner), Mode=OneWay}"
-                                        Content="Import"
-                                        x:Uid="Import"
-                                        Click="{x:Bind ImportSetting}"/>
-                            <Button w10v1809:CornerRadius="{x:Bind q:Converter.IntToCorner(QSetting.GlobalButtonCorner), Mode=OneWay}"
-                                        Content="Export"
-                                        x:Uid="Export"
-                                        Margin="5,2"
-                                        Click="{x:Bind ExportSettings}"/>
-                            <Button w10v1809:CornerRadius="{x:Bind q:Converter.IntToCorner(QSetting.GlobalButtonCorner), Mode=OneWay}"
-                                        Content="Reset"
-                                        x:Uid="Reset"
-                                        Click="{x:Bind ResetSettings}"/>
+                            <Button Content="Import" x:Uid="Import" Click="{x:Bind ImportSetting}"/>
+                            <Button Content="Export" x:Uid="Export" Margin="5,2" Click="{x:Bind ExportSettings}"/>
+                            <Button Content="Reset" x:Uid="Reset" Click="{x:Bind ResetSettings}"/>
                         </StackPanel>
                         <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Margin="0">
                                 <Run x:Uid="PleaseSaveWork" Text="Please save your work before you import or reset settings."/>

--- a/Quick Pad/Dialog/Settings.xaml
+++ b/Quick Pad/Dialog/Settings.xaml
@@ -20,13 +20,7 @@
                                   PaneDisplayMode="Top"
                                   HorizontalAlignment="Stretch"
                                   SelectedItem="{x:Bind SelectedNavigationItem, Mode=TwoWay}"
-                                  Header="{x:Bind SelectedNavigationItem.Content, Mode=OneWay}"
                                   OpenPaneLength="200">
-            <winui:NavigationView.HeaderTemplate>
-                <DataTemplate x:DataType="x:String">
-                    <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="{x:Bind}"/>                    
-                </DataTemplate>
-            </winui:NavigationView.HeaderTemplate>
             <!--Page selection-->
             <winui:NavigationView.MenuItems>
                 <winui:NavigationViewItem Tag="General" IsSelected="{x:Bind SyncWithPage(CurrentSettingPage, 'General'), Mode=OneWay}">

--- a/Quick Pad/Dialog/Settings.xaml.cs
+++ b/Quick Pad/Dialog/Settings.xaml.cs
@@ -196,6 +196,8 @@ namespace QuickPad.Dialog
         #endregion
 
         #region Languages
+        string currentSessionLanguage = null;
+
         int? _def_lang = null;
         public int SelectedDefaultLanguage
         {
@@ -214,9 +216,9 @@ namespace QuickPad.Dialog
                     Set(ref _def_lang, value);
                     if (value == -1)
                         return;
+                    currentSessionLanguage = currentSessionLanguage is null ? QSetting.AppLanguage : currentSessionLanguage;
                     ApplicationLanguages.PrimaryLanguageOverride = DefaultLanguages[value].ID;
-                    LangChangeNeedRestart.Visibility =
-                        ApplicationLanguages.PrimaryLanguageOverride == DefaultLanguages[value].ID
+                    LangChangeNeedRestart.Visibility = currentSessionLanguage == DefaultLanguages[value].ID
                         ? Visibility.Collapsed : Visibility.Visible;
                     QSetting.AppLanguage = DefaultLanguages[value].ID;
                 }

--- a/Quick Pad/MultilingualResources/Quick Pad.ar-SA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.ar-SA.xlf
@@ -1022,6 +1022,10 @@
           <source>No crashes have occured</source>
           <target state="translated">لا يوجد تحطم تطبيقي</target>
         </trans-unit>
+        <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
+          <source>Theme</source>
+          <target state="translated">نُسق</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.ar-SA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.ar-SA.xlf
@@ -358,26 +358,6 @@
           <source>Settings</source>
           <target state="translated">الإعدادات</target>
         </trans-unit>
-        <trans-unit id="SettingsTab1.Header" translate="yes" xml:space="preserve">
-          <source>General</source>
-          <target state="translated">عام</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab2.Header" translate="yes" xml:space="preserve">
-          <source>Theme</source>
-          <target state="translated">نُسق</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab3.Header" translate="yes" xml:space="preserve">
-          <source>Font</source>
-          <target state="translated">خطوط</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab4.Header" translate="yes" xml:space="preserve">
-          <source>Toolbar</source>
-          <target state="translated">شريط الأدوات</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab5.Header" translate="yes" xml:space="preserve">
-          <source>About</source>
-          <target state="translated">حول</target>
-        </trans-unit>
         <trans-unit id="ShowAlignCenter.OffContent" translate="yes" xml:space="preserve">
           <source>Hide align center</source>
           <target state="translated">إخفاء توسيط</target>
@@ -1025,6 +1005,10 @@
         <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
           <source>Theme</source>
           <target state="translated">نُسق</target>
+        </trans-unit>
+        <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
+          <source>Font</source>
+          <target state="translated">خطوط</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.ar-SA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.ar-SA.xlf
@@ -946,18 +946,6 @@
           <source>Advanced</source>
           <target state="translated">إعدادات متقدمة</target>
         </trans-unit>
-        <trans-unit id="Customize_Bold" translate="yes" xml:space="preserve">
-          <source>Show bold</source>
-          <target state="translated">عرض بالخط العريض</target>
-        </trans-unit>
-        <trans-unit id="Customize_Italic" translate="yes" xml:space="preserve">
-          <source>Show italic</source>
-          <target state="translated">عرض مائل</target>
-        </trans-unit>
-        <trans-unit id="Customize_Underline" translate="yes" xml:space="preserve">
-          <source>Show underline</source>
-          <target state="translated">عرض تسطير</target>
-        </trans-unit>
         <trans-unit id="KeepTextOnly.Text" translate="yes" xml:space="preserve">
           <source>Keep text only</source>
           <target state="translated">الحفاظ على النص فقط</target>
@@ -1009,6 +997,18 @@
         <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
           <source>Font</source>
           <target state="translated">خطوط</target>
+        </trans-unit>
+        <trans-unit id="Customize_Bold.Text" translate="yes" xml:space="preserve">
+          <source>Show bold</source>
+          <target state="translated">عرض بالخط العريض</target>
+        </trans-unit>
+        <trans-unit id="Customize_Italic.Text" translate="yes" xml:space="preserve">
+          <source>Show italic</source>
+          <target state="translated">عرض مائل</target>
+        </trans-unit>
+        <trans-unit id="Customize_Underline.Text" translate="yes" xml:space="preserve">
+          <source>Show underline</source>
+          <target state="translated">عرض تسطير</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.es.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.es.xlf
@@ -946,18 +946,6 @@
           <source>Advanced</source>
           <target state="translated">Avanzado</target>
         </trans-unit>
-        <trans-unit id="Customize_Bold" translate="yes" xml:space="preserve">
-          <source>Show bold</source>
-          <target state="translated">Mostrar negritas</target>
-        </trans-unit>
-        <trans-unit id="Customize_Italic" translate="yes" xml:space="preserve">
-          <source>Show italic</source>
-          <target state="translated">Mostrar cursiva</target>
-        </trans-unit>
-        <trans-unit id="Customize_Underline" translate="yes" xml:space="preserve">
-          <source>Show underline</source>
-          <target state="translated">Mostrar subrayado</target>
-        </trans-unit>
         <trans-unit id="KeepTextOnly.Text" translate="yes" xml:space="preserve">
           <source>Keep text only</source>
           <target state="translated">Mantener solo texto</target>
@@ -1009,6 +997,18 @@
         <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
           <source>Font</source>
           <target state="translated">Fuente</target>
+        </trans-unit>
+        <trans-unit id="Customize_Bold.Text" translate="yes" xml:space="preserve">
+          <source>Show bold</source>
+          <target state="translated">Mostrar negritas</target>
+        </trans-unit>
+        <trans-unit id="Customize_Italic.Text" translate="yes" xml:space="preserve">
+          <source>Show italic</source>
+          <target state="translated">Mostrar cursiva</target>
+        </trans-unit>
+        <trans-unit id="Customize_Underline.Text" translate="yes" xml:space="preserve">
+          <source>Show underline</source>
+          <target state="translated">Mostrar subrayado</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.es.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.es.xlf
@@ -1022,6 +1022,10 @@
           <source>No crashes have occured</source>
           <target state="translated">No han ocurrido errores</target>
         </trans-unit>
+        <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
+          <source>Theme</source>
+          <target state="translated">Tema</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.es.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.es.xlf
@@ -358,26 +358,6 @@
           <source>Settings</source>
           <target state="translated">Configuración</target>
         </trans-unit>
-        <trans-unit id="SettingsTab1.Header" translate="yes" xml:space="preserve">
-          <source>General</source>
-          <target state="translated">General</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab2.Header" translate="yes" xml:space="preserve">
-          <source>Theme</source>
-          <target state="translated">Tema</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab3.Header" translate="yes" xml:space="preserve">
-          <source>Font</source>
-          <target state="translated">Fuente</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab4.Header" translate="yes" xml:space="preserve">
-          <source>Toolbar</source>
-          <target state="translated">Barra de herramientas</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab5.Header" translate="yes" xml:space="preserve">
-          <source>About</source>
-          <target state="translated">Acerca de</target>
-        </trans-unit>
         <trans-unit id="ShowAlignCenter.OffContent" translate="yes" xml:space="preserve">
           <source>Hide align center</source>
           <target state="translated">Ocultar 'Alinear al centro'</target>
@@ -1025,6 +1005,10 @@
         <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
           <source>Theme</source>
           <target state="translated">Tema</target>
+        </trans-unit>
+        <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
+          <source>Font</source>
+          <target state="translated">Fuente</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
@@ -359,26 +359,6 @@
           <source>Settings</source>
           <target state="translated" state-qualifier="tm-suggestion">Paramètres</target>
         </trans-unit>
-        <trans-unit id="SettingsTab1.Header" translate="yes" xml:space="preserve">
-          <source>General</source>
-          <target state="translated" state-qualifier="tm-suggestion">Général</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab2.Header" translate="yes" xml:space="preserve">
-          <source>Theme</source>
-          <target state="translated" state-qualifier="tm-suggestion">Thème</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab3.Header" translate="yes" xml:space="preserve">
-          <source>Font</source>
-          <target state="translated">Police</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab4.Header" translate="yes" xml:space="preserve">
-          <source>Toolbar</source>
-          <target state="translated" state-qualifier="tm-suggestion">Barre d'outils</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab5.Header" translate="yes" xml:space="preserve">
-          <source>About</source>
-          <target state="translated">À propos</target>
-        </trans-unit>
         <trans-unit id="ShowAlignCenter.OffContent" translate="yes" xml:space="preserve">
           <source>Hide align center</source>
           <target state="translated">Cacher l'algnement au centre</target>
@@ -1027,6 +1007,10 @@
         <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
           <source>Theme</source>
           <target state="translated" state-qualifier="tm-suggestion">Thème</target>
+        </trans-unit>
+        <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
+          <source>Font</source>
+          <target state="translated">Police</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
@@ -918,7 +918,7 @@
         </trans-unit>
         <trans-unit id="General.Text" translate="yes" xml:space="preserve">
           <source>General</source>
-          <target state="new">General</target>
+          <target state="translated" state-qualifier="tm-suggestion">Général</target>
         </trans-unit>
         <trans-unit id="ThemeSettings.Text" translate="yes" xml:space="preserve">
           <source>Theme Settings</source>
@@ -1023,6 +1023,10 @@
         <trans-unit id="NoCrashes.Text" translate="yes" xml:space="preserve">
           <source>No crashes have occured</source>
           <target state="new">No crashes have occured</target>
+        </trans-unit>
+        <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
+          <source>Theme</source>
+          <target state="translated" state-qualifier="tm-suggestion">Thème</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-CA.xlf
@@ -948,18 +948,6 @@
           <source>Advanced</source>
           <target state="new">Advanced</target>
         </trans-unit>
-        <trans-unit id="Customize_Bold" translate="yes" xml:space="preserve">
-          <source>Show bold</source>
-          <target state="new">Show bold</target>
-        </trans-unit>
-        <trans-unit id="Customize_Italic" translate="yes" xml:space="preserve">
-          <source>Show italic</source>
-          <target state="new">Show italic</target>
-        </trans-unit>
-        <trans-unit id="Customize_Underline" translate="yes" xml:space="preserve">
-          <source>Show underline</source>
-          <target state="new">Show underline</target>
-        </trans-unit>
         <trans-unit id="KeepTextOnly.Text" translate="yes" xml:space="preserve">
           <source>Keep text only</source>
           <target state="new">Keep text only</target>
@@ -1011,6 +999,18 @@
         <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
           <source>Font</source>
           <target state="translated">Police</target>
+        </trans-unit>
+        <trans-unit id="Customize_Bold.Text" translate="yes" xml:space="preserve">
+          <source>Show bold</source>
+          <target state="new">Show bold</target>
+        </trans-unit>
+        <trans-unit id="Customize_Italic.Text" translate="yes" xml:space="preserve">
+          <source>Show italic</source>
+          <target state="new">Show italic</target>
+        </trans-unit>
+        <trans-unit id="Customize_Underline.Text" translate="yes" xml:space="preserve">
+          <source>Show underline</source>
+          <target state="new">Show underline</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-FR.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-FR.xlf
@@ -918,7 +918,7 @@
         </trans-unit>
         <trans-unit id="General.Text" translate="yes" xml:space="preserve">
           <source>General</source>
-          <target state="new">Général</target>
+          <target state="translated" state-qualifier="tm-suggestion">Général</target>
         </trans-unit>
         <trans-unit id="ThemeSettings.Text" translate="yes" xml:space="preserve">
           <source>Theme Settings</source>
@@ -1023,6 +1023,10 @@
         <trans-unit id="NoCrashes.Text" translate="yes" xml:space="preserve">
           <source>No crashes have occured</source>
           <target state="new">No crashes have occured</target>
+        </trans-unit>
+        <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
+          <source>Theme</source>
+          <target state="translated" state-qualifier="tm-suggestion">Thème</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-FR.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-FR.xlf
@@ -359,26 +359,6 @@
           <source>Settings</source>
           <target state="translated" state-qualifier="tm-suggestion">Paramètres</target>
         </trans-unit>
-        <trans-unit id="SettingsTab1.Header" translate="yes" xml:space="preserve">
-          <source>General</source>
-          <target state="translated" state-qualifier="tm-suggestion">Général</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab2.Header" translate="yes" xml:space="preserve">
-          <source>Theme</source>
-          <target state="translated" state-qualifier="tm-suggestion">Thème</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab3.Header" translate="yes" xml:space="preserve">
-          <source>Font</source>
-          <target state="translated">Police</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab4.Header" translate="yes" xml:space="preserve">
-          <source>Toolbar</source>
-          <target state="translated" state-qualifier="tm-suggestion">Barre d'outils</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab5.Header" translate="yes" xml:space="preserve">
-          <source>About</source>
-          <target state="translated">À propos</target>
-        </trans-unit>
         <trans-unit id="ShowAlignCenter.OffContent" translate="yes" xml:space="preserve">
           <source>Hide align center</source>
           <target state="translated">Cacher l'algnement au centre</target>
@@ -1027,6 +1007,10 @@
         <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
           <source>Theme</source>
           <target state="translated" state-qualifier="tm-suggestion">Thème</target>
+        </trans-unit>
+        <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
+          <source>Font</source>
+          <target state="translated">Police</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.fr-FR.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.fr-FR.xlf
@@ -948,18 +948,6 @@
           <source>Advanced</source>
           <target state="new">Advanced</target>
         </trans-unit>
-        <trans-unit id="Customize_Bold" translate="yes" xml:space="preserve">
-          <source>Show bold</source>
-          <target state="new">Show bold</target>
-        </trans-unit>
-        <trans-unit id="Customize_Italic" translate="yes" xml:space="preserve">
-          <source>Show italic</source>
-          <target state="new">Show italic</target>
-        </trans-unit>
-        <trans-unit id="Customize_Underline" translate="yes" xml:space="preserve">
-          <source>Show underline</source>
-          <target state="new">Show underline</target>
-        </trans-unit>
         <trans-unit id="KeepTextOnly.Text" translate="yes" xml:space="preserve">
           <source>Keep text only</source>
           <target state="new">Keep text only</target>
@@ -1011,6 +999,18 @@
         <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
           <source>Font</source>
           <target state="translated">Police</target>
+        </trans-unit>
+        <trans-unit id="Customize_Bold.Text" translate="yes" xml:space="preserve">
+          <source>Show bold</source>
+          <target state="new">Show bold</target>
+        </trans-unit>
+        <trans-unit id="Customize_Italic.Text" translate="yes" xml:space="preserve">
+          <source>Show italic</source>
+          <target state="new">Show italic</target>
+        </trans-unit>
+        <trans-unit id="Customize_Underline.Text" translate="yes" xml:space="preserve">
+          <source>Show underline</source>
+          <target state="new">Show underline</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -268,8 +268,7 @@
         </trans-unit>
         <trans-unit id="ErrorDialogContent" translate="yes" xml:space="preserve">
           <source>Sorry, Quick Pad couldn't open this file.</source>
-          <target state="needs-review-translation">ไม่สามารถเปิดไฟล์นี้ได้</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">ไม่สามารถเปิดไฟล์นี้ได้</target>
         </trans-unit>
         <trans-unit id="ErrorDialogOk" translate="yes" xml:space="preserve">
           <source>Ok</source>
@@ -841,9 +840,8 @@
         </trans-unit>
         <trans-unit id="HowToLeaveFocus.Subtitle" translate="yes" xml:space="preserve">
           <source>We moved the button here for a cleaner look! You can also press Control + Shift + F to leave focus mode.</source>
-          <target state="needs-review-translation">ปุ่ม "ออกจากโหมดเน้นพิมพ์" ถูกย้ายมาไว้ตรงนี้ เพื่อให้แอปโล่งขึ้น
+          <target state="translated">ปุ่ม "ออกจากโหมดเน้นพิมพ์" ถูกย้ายมาไว้ตรงนี้ เพื่อให้แอปโล่งขึ้น
 หรือกด Control + Shift + F เพื่อออกจากโหมดเน้นพิมพ์</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="HowToLeaveFocus.Title" translate="yes" xml:space="preserve">
           <source>The button to leave focus mode button has been moved</source>
@@ -919,111 +917,115 @@
         </trans-unit>
         <trans-unit id="General.Text" translate="yes" xml:space="preserve">
           <source>General</source>
-          <target state="new">General</target>
+          <target state="translated">ทั่วไป</target>
         </trans-unit>
         <trans-unit id="ThemeSettings.Text" translate="yes" xml:space="preserve">
           <source>Theme Settings</source>
-          <target state="new">Theme Settings</target>
+          <target state="translated">ชุดรูปแบบ</target>
         </trans-unit>
         <trans-unit id="FontSettings.Text" translate="yes" xml:space="preserve">
           <source>Font Settings</source>
-          <target state="new">Font Settings</target>
+          <target state="translated">ฟอนต์</target>
         </trans-unit>
         <trans-unit id="AutoPickMode.Text" translate="yes" xml:space="preserve">
           <source>Automatically choose which mode to launch the app in based on the file type</source>
-          <target state="new">Automatically choose which mode to launch the app in based on the file type</target>
+          <target state="translated">เลือกโหมดหน้าตาของแอปโดยอัตโนมัติตามไฟล์ที่เปิด</target>
         </trans-unit>
         <trans-unit id="BackgroundTintOpacity.Text" translate="yes" xml:space="preserve">
           <source>App background tint opacity</source>
-          <target state="new">App background tint opacity</target>
+          <target state="translated">ความโปร่งใสของพื้นหลัง</target>
         </trans-unit>
         <trans-unit id="Export.Content" translate="yes" xml:space="preserve">
           <source>Export</source>
-          <target state="new">Export</target>
+          <target state="translated">ส่งออก</target>
         </trans-unit>
         <trans-unit id="Import.Content" translate="yes" xml:space="preserve">
           <source>Import</source>
-          <target state="new">Import</target>
+          <target state="translated">นำเข้า</target>
         </trans-unit>
         <trans-unit id="ManageSettings.Text" translate="yes" xml:space="preserve">
           <source>Manage settings</source>
-          <target state="new">Manage settings</target>
+          <target state="translated">จัดการตั้งค่า</target>
         </trans-unit>
         <trans-unit id="PleaseSaveWork.Text" translate="yes" xml:space="preserve">
           <source>Please save your work before you import or reset settings.</source>
-          <target state="new">Please save your work before you import or reset settings.</target>
+          <target state="translated">กรุณาบันทึกสิ่งที่คุณพิมพ์ไว้ก่อนที่จะนำเข้าหรือรีเซตตั้งค่า</target>
         </trans-unit>
         <trans-unit id="PreventText1ChangeColor.Text" translate="yes" xml:space="preserve">
           <source>Use a dark/light background for the text area</source>
-          <target state="new">Use a dark/light background for the text area</target>
+          <target state="translated">ใช้สีทืบสำหรับพื้นหลังของบริเวณที่พิมพ์</target>
         </trans-unit>
         <trans-unit id="Reset.Content" translate="yes" xml:space="preserve">
           <source>Reset</source>
-          <target state="new">Reset</target>
+          <target state="translated">รีเซต</target>
         </trans-unit>
         <trans-unit id="SomeSettings.Text" translate="yes" xml:space="preserve">
           <source>Some settings will not update until you restart.</source>
-          <target state="new">Some settings will not update until you restart.</target>
+          <target state="translated">การตั้งค่าบางส่วนจะไม่อัพเดตจนกว่าแอปจะเปิดใหม่ครั้งหน้า</target>
         </trans-unit>
         <trans-unit id="Advanced.Text" translate="yes" xml:space="preserve">
           <source>Advanced</source>
-          <target state="new">Advanced</target>
+          <target state="translated">ขั้นสูง</target>
         </trans-unit>
         <trans-unit id="Customize_Bold" translate="yes" xml:space="preserve">
           <source>Show bold</source>
-          <target state="new">Show bold</target>
+          <target state="translated">แสดงปุ่มตัวหนา</target>
         </trans-unit>
         <trans-unit id="Customize_Italic" translate="yes" xml:space="preserve">
           <source>Show italic</source>
-          <target state="new">Show italic</target>
+          <target state="translated">แสดงปุ่มตัวเอียง</target>
         </trans-unit>
         <trans-unit id="Customize_Underline" translate="yes" xml:space="preserve">
           <source>Show underline</source>
-          <target state="new">Show underline</target>
+          <target state="translated">แสดงปุ่มขีดเส้นใต้</target>
         </trans-unit>
         <trans-unit id="KeepTextOnly.Text" translate="yes" xml:space="preserve">
           <source>Keep text only</source>
-          <target state="new">Keep text only</target>
+          <target state="translated">วางเฉพาะข้อความ</target>
         </trans-unit>
         <trans-unit id="AdvancedPasteOptions.Text" translate="yes" xml:space="preserve">
           <source>Paste Options</source>
-          <target state="new">Paste Options</target>
+          <target state="translated">ตั้งค่าการวางข้อความ</target>
         </trans-unit>
         <trans-unit id="AdvancedOther.Text" translate="yes" xml:space="preserve">
           <source>Other</source>
-          <target state="new">Other</target>
+          <target state="translated">อื่นๆ</target>
         </trans-unit>
         <trans-unit id="AdvancedThemeOptions.Text" translate="yes" xml:space="preserve">
           <source>Theme Options</source>
-          <target state="new">Theme Options</target>
+          <target state="translated">ชุดรูปแบบขั้นสูง</target>
         </trans-unit>
         <trans-unit id="Health.Text" translate="yes" xml:space="preserve">
           <source>Health</source>
-          <target state="new">Health</target>
+          <target state="translated">สภาพแอป</target>
         </trans-unit>
         <trans-unit id="GiveChanceToSave.Text" translate="yes" xml:space="preserve">
           <source>Give yourself a chance to save or copy your work, you will still need to restart as some functions may not work properly.</source>
-          <target state="new">Give yourself a chance to save or copy your work, you will still need to restart as some functions may not work properly.</target>
+          <target state="translated">บังคับไม่ให้แอปปิดตัวลงเมื่อมีปัญหา เพื่อให้คุณได้บันทึกหรือคัดลอกงานของคุณ. แต่คุณยังต้องปิดแล้วเปิดแอปใหม่เพื่อให้ฟังก์ชั่นของแอปกลับมา</target>
         </trans-unit>
         <trans-unit id="PreventAppCloseAfterCrash.Content" translate="yes" xml:space="preserve">
           <source>Prevent the app from closing when a crash occurs</source>
-          <target state="new">Prevent the app from closing when a crash occurs</target>
+          <target state="translated">ป้องกันแอปบังคับปิดเมื่อเกิดข้อผิดพลาด</target>
         </trans-unit>
         <trans-unit id="SaveLogWhenCrash.Content" translate="yes" xml:space="preserve">
           <source>Save log reports when the app crashes</source>
-          <target state="new">Save log reports when the app crashes</target>
+          <target state="translated">บันทึกข้อมูลข้อผิดพลาดเมื่อแอปมีปัญหา</target>
         </trans-unit>
         <trans-unit id="SendAnalyticsReport.Content" translate="yes" xml:space="preserve">
           <source>Send app health reports to App Center</source>
-          <target state="new">Send app health reports to App Center</target>
+          <target state="translated">ส่งสถานะภาพแอปให้นักพัฒนา</target>
         </trans-unit>
         <trans-unit id="ClearCrashList.Content" translate="yes" xml:space="preserve">
           <source>Clear crash history</source>
-          <target state="new">Clear crash history</target>
+          <target state="translated">ลบประวัติข้อผิดพลาด</target>
         </trans-unit>
         <trans-unit id="NoCrashes.Text" translate="yes" xml:space="preserve">
           <source>No crashes have occured</source>
-          <target state="new">No crashes have occured</target>
+          <target state="translated">ยังไม่มีข้อผิดพลาดใดๆ</target>
+        </trans-unit>
+        <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
+          <source>Theme</source>
+          <target state="translated" state-qualifier="tm-suggestion">ธีม</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -947,18 +947,6 @@
           <source>Advanced</source>
           <target state="translated">ขั้นสูง</target>
         </trans-unit>
-        <trans-unit id="Customize_Bold" translate="yes" xml:space="preserve">
-          <source>Show bold</source>
-          <target state="translated">แสดงปุ่มตัวหนา</target>
-        </trans-unit>
-        <trans-unit id="Customize_Italic" translate="yes" xml:space="preserve">
-          <source>Show italic</source>
-          <target state="translated">แสดงปุ่มตัวเอียง</target>
-        </trans-unit>
-        <trans-unit id="Customize_Underline" translate="yes" xml:space="preserve">
-          <source>Show underline</source>
-          <target state="translated">แสดงปุ่มขีดเส้นใต้</target>
-        </trans-unit>
         <trans-unit id="KeepTextOnly.Text" translate="yes" xml:space="preserve">
           <source>Keep text only</source>
           <target state="translated">วางเฉพาะข้อความ</target>
@@ -1010,6 +998,18 @@
         <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
           <source>Font</source>
           <target state="translated" state-qualifier="tm-suggestion">แบบอักษร</target>
+        </trans-unit>
+        <trans-unit id="Customize_Bold.Text" translate="yes" xml:space="preserve">
+          <source>Show bold</source>
+          <target state="translated">แสดงปุ่มตัวหนา</target>
+        </trans-unit>
+        <trans-unit id="Customize_Italic.Text" translate="yes" xml:space="preserve">
+          <source>Show italic</source>
+          <target state="translated">แสดงปุ่มตัวเอียง</target>
+        </trans-unit>
+        <trans-unit id="Customize_Underline.Text" translate="yes" xml:space="preserve">
+          <source>Show underline</source>
+          <target state="translated">แสดงปุ่มขีดเส้นใต้</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -166,26 +166,6 @@
           <source>Settings</source>
           <target state="translated" state-qualifier="tm-suggestion">การตั้งค่า</target>
         </trans-unit>
-        <trans-unit id="SettingsTab1.Header" translate="yes" xml:space="preserve">
-          <source>General</source>
-          <target state="translated" state-qualifier="tm-suggestion">ทั่วไป</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab2.Header" translate="yes" xml:space="preserve">
-          <source>Theme</source>
-          <target state="translated" state-qualifier="tm-suggestion">ธีม</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab3.Header" translate="yes" xml:space="preserve">
-          <source>Font</source>
-          <target state="translated" state-qualifier="tm-suggestion">แบบอักษร</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab4.Header" translate="yes" xml:space="preserve">
-          <source>Toolbar</source>
-          <target state="translated" state-qualifier="tm-suggestion">แถบเครื่องมือ</target>
-        </trans-unit>
-        <trans-unit id="SettingsTab5.Header" translate="yes" xml:space="preserve">
-          <source>About</source>
-          <target state="translated" state-qualifier="tm-suggestion">เกี่ยวกับ</target>
-        </trans-unit>
         <trans-unit id="ShowAlignCenter.OffContent" translate="yes" xml:space="preserve">
           <source>Hide align center</source>
           <target state="translated">ซ่อนปุ่มจัดกลาง</target>
@@ -1026,6 +1006,10 @@
         <trans-unit id="Theme.Text" translate="yes" xml:space="preserve">
           <source>Theme</source>
           <target state="translated" state-qualifier="tm-suggestion">ธีม</target>
+        </trans-unit>
+        <trans-unit id="Font.Text" translate="yes" xml:space="preserve">
+          <source>Font</source>
+          <target state="translated" state-qualifier="tm-suggestion">แบบอักษร</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -432,20 +432,6 @@ namespace QuickPad
             set => Set(value);
         }
 
-        [DefaultValue(2)]
-        public int GlobalButtonCorner
-        {
-            get => Get<int>();
-            set => Set(value);
-        }
-
-        [DefaultValue(4)]
-        public int GlobalDialogCorner
-        {
-            get => Get<int>();
-            set => Set(value);
-        }
-
         [DefaultValue(true)]
         public bool SendAnalyticsReport
         {

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -585,18 +585,6 @@ namespace QuickPad
         }
 
         /// <summary>
-        /// Use to convert on XAML & x:Bind from ElementTheme and string to boolean
-        /// If the ElementTheme match string it will return true, otherwise false
-        /// </summary>
-        /// <param name="input">ThemeElement setting</param>
-        /// <param name="expect">Expected value in string</param>
-        public static bool ThemeToBool(ElementTheme input, string expect)
-        {
-            var convert = (ElementTheme)Enum.Parse(typeof(ElementTheme), expect);
-            return Equals(input, convert);
-        }
-
-        /// <summary>
         /// Use to convert on XAML & x:Bind from bool (or Boolean) to Visibility
         /// </summary>
         /// <param name="input">Any boolean input</param>
@@ -625,15 +613,6 @@ namespace QuickPad
             return Visibility.Visible;
         }
 
-        /// <summary>
-        /// A very specific converter use on XAML and x:Bind that only use on align button separator
-        /// By tying all visibility setting into one place and when all 4 is false it will return Visible
-        /// </summary>
-        /// <param name="left">Left align button</param>
-        /// <param name="center">Center align button</param>
-        /// <param name="right">Right align button</param>
-        /// <param name="justify">Justify align button</param>
-        /// <returns></returns>
         public static Visibility HideIfNoBulletOptionsShow(bool bullet, bool bold, bool strikethrough, bool underline, bool italic)
         {
             if (!bullet && !bold && !strikethrough && !underline && !italic)
@@ -695,21 +674,6 @@ namespace QuickPad
             }
         }
 
-        public static string FromColorToHex(Color input)
-        {
-            return $"#{input.A.ToString("16")}{input.R.ToString("16")}{input.G.ToString("16")}{input.B.ToString("16")}";
-        }
-
-        public static Color FromHexToColor(string input)
-        {
-            input = input.Substring(1);
-            byte a = (byte)Convert.ToUInt32(input.Substring(0, 2), 16);
-            byte r = (byte)Convert.ToUInt32(input.Substring(2, 2), 16);
-            byte g = (byte)Convert.ToUInt32(input.Substring(4, 2), 16);
-            byte b = (byte)Convert.ToUInt32(input.Substring(6, 2), 16);
-            return Color.FromArgb(a, r, g, b);
-        }
-
         /// <summary>
         /// Use to check if input item is null or not
         /// </summary>
@@ -719,13 +683,6 @@ namespace QuickPad
         {
             return item is null;
         }
-
-        /// <summary>
-        /// Use in XAML binding, if item is null show that UI, if item is not null hide the UI
-        /// </summary>
-        /// <param name="input">anything</param>
-        /// <returns></returns>
-        public static Visibility ShowIfItemIsNull(object input) => IsItemNull(input) ? Visibility.Visible : Visibility.Collapsed;
 
         /// <summary>
         /// Use in XAML binding, if item is null hide that UI, if item is not null show the UI
@@ -778,11 +735,6 @@ namespace QuickPad
         public static Visibility ShowAfterCompareNumber(int number, string compareType, int target)
         {
             return CompareNumber(number, compareType, target) ? Visibility.Visible : Visibility.Collapsed;
-        }
-
-        public static FontFamily FontNameToFontFamily(string name)
-        {
-            return new FontFamily(name);
         }
 
         public static CornerRadius IntToCorner(int corner)

--- a/Quick Pad/Strings/ar-SA/Resources.resw
+++ b/Quick Pad/Strings/ar-SA/Resources.resw
@@ -717,15 +717,6 @@
   <data name="Advanced.Text" xml:space="preserve">
     <value>إعدادات متقدمة</value>
   </data>
-  <data name="Customize_Bold" xml:space="preserve">
-    <value>عرض بالخط العريض</value>
-  </data>
-  <data name="Customize_Italic" xml:space="preserve">
-    <value>عرض مائل</value>
-  </data>
-  <data name="Customize_Underline" xml:space="preserve">
-    <value>عرض تسطير</value>
-  </data>
   <data name="KeepTextOnly.Text" xml:space="preserve">
     <value>الحفاظ على النص فقط</value>
   </data>
@@ -764,5 +755,14 @@
   </data>
   <data name="Font.Text" xml:space="preserve">
     <value>خطوط</value>
+  </data>
+  <data name="Customize_Bold.Text" xml:space="preserve">
+    <value>عرض بالخط العريض</value>
+  </data>
+  <data name="Customize_Italic.Text" xml:space="preserve">
+    <value>عرض مائل</value>
+  </data>
+  <data name="Customize_Underline.Text" xml:space="preserve">
+    <value>عرض تسطير</value>
   </data>
 </root>

--- a/Quick Pad/Strings/ar-SA/Resources.resw
+++ b/Quick Pad/Strings/ar-SA/Resources.resw
@@ -774,4 +774,7 @@
   <data name="NoCrashes.Text" xml:space="preserve">
     <value>لا يوجد تحطم تطبيقي</value>
   </data>
+  <data name="Theme.Text" xml:space="preserve">
+    <value>نُسق</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/ar-SA/Resources.resw
+++ b/Quick Pad/Strings/ar-SA/Resources.resw
@@ -276,21 +276,6 @@
   <data name="SettingsPivot.Title" xml:space="preserve">
     <value>الإعدادات</value>
   </data>
-  <data name="SettingsTab1.Header" xml:space="preserve">
-    <value>عام</value>
-  </data>
-  <data name="SettingsTab2.Header" xml:space="preserve">
-    <value>نُسق</value>
-  </data>
-  <data name="SettingsTab3.Header" xml:space="preserve">
-    <value>خطوط</value>
-  </data>
-  <data name="SettingsTab4.Header" xml:space="preserve">
-    <value>شريط الأدوات</value>
-  </data>
-  <data name="SettingsTab5.Header" xml:space="preserve">
-    <value>حول</value>
-  </data>
   <data name="ShowAlignCenter.OffContent" xml:space="preserve">
     <value>إخفاء توسيط</value>
   </data>
@@ -776,5 +761,8 @@
   </data>
   <data name="Theme.Text" xml:space="preserve">
     <value>نُسق</value>
+  </data>
+  <data name="Font.Text" xml:space="preserve">
+    <value>خطوط</value>
   </data>
 </root>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -879,4 +879,7 @@
   <data name="NoCrashes.Text" xml:space="preserve">
     <value>No crashes have occured</value>
   </data>
+  <data name="Theme.Text" xml:space="preserve">
+    <value>Theme</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -822,13 +822,13 @@
   <data name="KeepTextOnly.Text" xml:space="preserve">
     <value>Keep text only</value>
   </data>
-  <data name="Customize_Bold" xml:space="preserve">
+  <data name="Customize_Bold.Text" xml:space="preserve">
     <value>Show bold</value>
   </data>
-  <data name="Customize_Italic" xml:space="preserve">
+  <data name="Customize_Italic.Text" xml:space="preserve">
     <value>Show italic</value>
   </data>
-  <data name="Customize_Underline" xml:space="preserve">
+  <data name="Customize_Underline.Text" xml:space="preserve">
     <value>Show underline</value>
   </data>
   <data name="AdvancedPasteOptions.Text" xml:space="preserve">

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -381,21 +381,6 @@
   <data name="SettingsPivot.Title" xml:space="preserve">
     <value>Settings</value>
   </data>
-  <data name="SettingsTab1.Header" xml:space="preserve">
-    <value>General</value>
-  </data>
-  <data name="SettingsTab2.Header" xml:space="preserve">
-    <value>Theme</value>
-  </data>
-  <data name="SettingsTab3.Header" xml:space="preserve">
-    <value>Font</value>
-  </data>
-  <data name="SettingsTab4.Header" xml:space="preserve">
-    <value>Toolbar</value>
-  </data>
-  <data name="SettingsTab5.Header" xml:space="preserve">
-    <value>About</value>
-  </data>
   <data name="ShowAlignCenter.OffContent" xml:space="preserve">
     <value>Hide align center</value>
   </data>
@@ -416,9 +401,6 @@
   </data>
   <data name="ShowAlignRight.OffContent" xml:space="preserve">
     <value>Hide align right</value>
-  </data>
-  <data name="ShowAlignRight.OnContent" xml:space="preserve">
-    <value>Show align right</value>
   </data>
   <data name="ShowBullets.OffContent" xml:space="preserve">
     <value>Hide bullet list</value>
@@ -881,5 +863,11 @@
   </data>
   <data name="Theme.Text" xml:space="preserve">
     <value>Theme</value>
+  </data>
+  <data name="Font.Text" xml:space="preserve">
+    <value>Font</value>
+  </data>
+  <data name="ShowAlignRight.OnContent" xml:space="preserve">
+    <value>Show align right</value>
   </data>
 </root>

--- a/Quick Pad/Strings/es/Resources.resw
+++ b/Quick Pad/Strings/es/Resources.resw
@@ -717,15 +717,6 @@
   <data name="Advanced.Text" xml:space="preserve">
     <value>Avanzado</value>
   </data>
-  <data name="Customize_Bold" xml:space="preserve">
-    <value>Mostrar negritas</value>
-  </data>
-  <data name="Customize_Italic" xml:space="preserve">
-    <value>Mostrar cursiva</value>
-  </data>
-  <data name="Customize_Underline" xml:space="preserve">
-    <value>Mostrar subrayado</value>
-  </data>
   <data name="KeepTextOnly.Text" xml:space="preserve">
     <value>Mantener solo texto</value>
   </data>
@@ -764,5 +755,14 @@
   </data>
   <data name="Font.Text" xml:space="preserve">
     <value>Fuente</value>
+  </data>
+  <data name="Customize_Bold.Text" xml:space="preserve">
+    <value>Mostrar negritas</value>
+  </data>
+  <data name="Customize_Italic.Text" xml:space="preserve">
+    <value>Mostrar cursiva</value>
+  </data>
+  <data name="Customize_Underline.Text" xml:space="preserve">
+    <value>Mostrar subrayado</value>
   </data>
 </root>

--- a/Quick Pad/Strings/es/Resources.resw
+++ b/Quick Pad/Strings/es/Resources.resw
@@ -774,4 +774,7 @@
   <data name="NoCrashes.Text" xml:space="preserve">
     <value>No han ocurrido errores</value>
   </data>
+  <data name="Theme.Text" xml:space="preserve">
+    <value>Tema</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/es/Resources.resw
+++ b/Quick Pad/Strings/es/Resources.resw
@@ -276,21 +276,6 @@
   <data name="SettingsPivot.Title" xml:space="preserve">
     <value>Configuración</value>
   </data>
-  <data name="SettingsTab1.Header" xml:space="preserve">
-    <value>General</value>
-  </data>
-  <data name="SettingsTab2.Header" xml:space="preserve">
-    <value>Tema</value>
-  </data>
-  <data name="SettingsTab3.Header" xml:space="preserve">
-    <value>Fuente</value>
-  </data>
-  <data name="SettingsTab4.Header" xml:space="preserve">
-    <value>Barra de herramientas</value>
-  </data>
-  <data name="SettingsTab5.Header" xml:space="preserve">
-    <value>Acerca de</value>
-  </data>
   <data name="ShowAlignCenter.OffContent" xml:space="preserve">
     <value>Ocultar 'Alinear al centro'</value>
   </data>
@@ -776,5 +761,8 @@
   </data>
   <data name="Theme.Text" xml:space="preserve">
     <value>Tema</value>
+  </data>
+  <data name="Font.Text" xml:space="preserve">
+    <value>Fuente</value>
   </data>
 </root>

--- a/Quick Pad/Strings/fr-CA/Resources.resw
+++ b/Quick Pad/Strings/fr-CA/Resources.resw
@@ -276,21 +276,6 @@
   <data name="SettingsPivot.Title" xml:space="preserve">
     <value>Paramètres</value>
   </data>
-  <data name="SettingsTab1.Header" xml:space="preserve">
-    <value>Général</value>
-  </data>
-  <data name="SettingsTab2.Header" xml:space="preserve">
-    <value>Thème</value>
-  </data>
-  <data name="SettingsTab3.Header" xml:space="preserve">
-    <value>Police</value>
-  </data>
-  <data name="SettingsTab4.Header" xml:space="preserve">
-    <value>Barre d'outils</value>
-  </data>
-  <data name="SettingsTab5.Header" xml:space="preserve">
-    <value>À propos</value>
-  </data>
   <data name="ShowAlignCenter.OffContent" xml:space="preserve">
     <value>Cacher l'algnement au centre</value>
   </data>
@@ -698,5 +683,8 @@
   </data>
   <data name="Theme.Text" xml:space="preserve">
     <value>Thème</value>
+  </data>
+  <data name="Font.Text" xml:space="preserve">
+    <value>Police</value>
   </data>
 </root>

--- a/Quick Pad/Strings/fr-CA/Resources.resw
+++ b/Quick Pad/Strings/fr-CA/Resources.resw
@@ -693,4 +693,10 @@
   <data name="ThemeSystemDescription" xml:space="preserve">
     <value>Thème défini par le système</value>
   </data>
+  <data name="General.Text" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="Theme.Text" xml:space="preserve">
+    <value>Thème</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/fr-FR/Resources.resw
+++ b/Quick Pad/Strings/fr-FR/Resources.resw
@@ -276,21 +276,6 @@
   <data name="SettingsPivot.Title" xml:space="preserve">
     <value>Paramètres</value>
   </data>
-  <data name="SettingsTab1.Header" xml:space="preserve">
-    <value>Général</value>
-  </data>
-  <data name="SettingsTab2.Header" xml:space="preserve">
-    <value>Thème</value>
-  </data>
-  <data name="SettingsTab3.Header" xml:space="preserve">
-    <value>Police</value>
-  </data>
-  <data name="SettingsTab4.Header" xml:space="preserve">
-    <value>Barre d'outils</value>
-  </data>
-  <data name="SettingsTab5.Header" xml:space="preserve">
-    <value>À propos</value>
-  </data>
   <data name="ShowAlignCenter.OffContent" xml:space="preserve">
     <value>Cacher l'algnement au centre</value>
   </data>
@@ -698,5 +683,8 @@
   </data>
   <data name="Theme.Text" xml:space="preserve">
     <value>Thème</value>
+  </data>
+  <data name="Font.Text" xml:space="preserve">
+    <value>Police</value>
   </data>
 </root>

--- a/Quick Pad/Strings/fr-FR/Resources.resw
+++ b/Quick Pad/Strings/fr-FR/Resources.resw
@@ -693,4 +693,10 @@
   <data name="ThemeSystemDescription" xml:space="preserve">
     <value>Thème défini par le système</value>
   </data>
+  <data name="General.Text" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="Theme.Text" xml:space="preserve">
+    <value>Thème</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -694,4 +694,88 @@
   <data name="ThemeSystemDescription" xml:space="preserve">
     <value>ใช้ชุดรูปแบบตามที่ระบบกำหนดไว้</value>
   </data>
+  <data name="General.Text" xml:space="preserve">
+    <value>ทั่วไป</value>
+  </data>
+  <data name="ThemeSettings.Text" xml:space="preserve">
+    <value>ชุดรูปแบบ</value>
+  </data>
+  <data name="FontSettings.Text" xml:space="preserve">
+    <value>ฟอนต์</value>
+  </data>
+  <data name="AutoPickMode.Text" xml:space="preserve">
+    <value>เลือกโหมดหน้าตาของแอปโดยอัตโนมัติตามไฟล์ที่เปิด</value>
+  </data>
+  <data name="BackgroundTintOpacity.Text" xml:space="preserve">
+    <value>ความโปร่งใสของพื้นหลัง</value>
+  </data>
+  <data name="Export.Content" xml:space="preserve">
+    <value>ส่งออก</value>
+  </data>
+  <data name="Import.Content" xml:space="preserve">
+    <value>นำเข้า</value>
+  </data>
+  <data name="ManageSettings.Text" xml:space="preserve">
+    <value>จัดการตั้งค่า</value>
+  </data>
+  <data name="PleaseSaveWork.Text" xml:space="preserve">
+    <value>กรุณาบันทึกสิ่งที่คุณพิมพ์ไว้ก่อนที่จะนำเข้าหรือรีเซตตั้งค่า</value>
+  </data>
+  <data name="PreventText1ChangeColor.Text" xml:space="preserve">
+    <value>ใช้สีทืบสำหรับพื้นหลังของบริเวณที่พิมพ์</value>
+  </data>
+  <data name="Reset.Content" xml:space="preserve">
+    <value>รีเซต</value>
+  </data>
+  <data name="SomeSettings.Text" xml:space="preserve">
+    <value>การตั้งค่าบางส่วนจะไม่อัพเดตจนกว่าแอปจะเปิดใหม่ครั้งหน้า</value>
+  </data>
+  <data name="Advanced.Text" xml:space="preserve">
+    <value>ขั้นสูง</value>
+  </data>
+  <data name="Customize_Bold" xml:space="preserve">
+    <value>แสดงปุ่มตัวหนา</value>
+  </data>
+  <data name="Customize_Italic" xml:space="preserve">
+    <value>แสดงปุ่มตัวเอียง</value>
+  </data>
+  <data name="Customize_Underline" xml:space="preserve">
+    <value>แสดงปุ่มขีดเส้นใต้</value>
+  </data>
+  <data name="KeepTextOnly.Text" xml:space="preserve">
+    <value>วางเฉพาะข้อความ</value>
+  </data>
+  <data name="AdvancedPasteOptions.Text" xml:space="preserve">
+    <value>ตั้งค่าการวางข้อความ</value>
+  </data>
+  <data name="AdvancedOther.Text" xml:space="preserve">
+    <value>อื่นๆ</value>
+  </data>
+  <data name="AdvancedThemeOptions.Text" xml:space="preserve">
+    <value>ชุดรูปแบบขั้นสูง</value>
+  </data>
+  <data name="Health.Text" xml:space="preserve">
+    <value>สภาพแอป</value>
+  </data>
+  <data name="GiveChanceToSave.Text" xml:space="preserve">
+    <value>บังคับไม่ให้แอปปิดตัวลงเมื่อมีปัญหา เพื่อให้คุณได้บันทึกหรือคัดลอกงานของคุณ. แต่คุณยังต้องปิดแล้วเปิดแอปใหม่เพื่อให้ฟังก์ชั่นของแอปกลับมา</value>
+  </data>
+  <data name="PreventAppCloseAfterCrash.Content" xml:space="preserve">
+    <value>ป้องกันแอปบังคับปิดเมื่อเกิดข้อผิดพลาด</value>
+  </data>
+  <data name="SaveLogWhenCrash.Content" xml:space="preserve">
+    <value>บันทึกข้อมูลข้อผิดพลาดเมื่อแอปมีปัญหา</value>
+  </data>
+  <data name="SendAnalyticsReport.Content" xml:space="preserve">
+    <value>ส่งสถานะภาพแอปให้นักพัฒนา</value>
+  </data>
+  <data name="ClearCrashList.Content" xml:space="preserve">
+    <value>ลบประวัติข้อผิดพลาด</value>
+  </data>
+  <data name="NoCrashes.Text" xml:space="preserve">
+    <value>ยังไม่มีข้อผิดพลาดใดๆ</value>
+  </data>
+  <data name="Theme.Text" xml:space="preserve">
+    <value>ธีม</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -718,15 +718,6 @@
   <data name="Advanced.Text" xml:space="preserve">
     <value>ขั้นสูง</value>
   </data>
-  <data name="Customize_Bold" xml:space="preserve">
-    <value>แสดงปุ่มตัวหนา</value>
-  </data>
-  <data name="Customize_Italic" xml:space="preserve">
-    <value>แสดงปุ่มตัวเอียง</value>
-  </data>
-  <data name="Customize_Underline" xml:space="preserve">
-    <value>แสดงปุ่มขีดเส้นใต้</value>
-  </data>
   <data name="KeepTextOnly.Text" xml:space="preserve">
     <value>วางเฉพาะข้อความ</value>
   </data>
@@ -765,5 +756,14 @@
   </data>
   <data name="Font.Text" xml:space="preserve">
     <value>แบบอักษร</value>
+  </data>
+  <data name="Customize_Bold.Text" xml:space="preserve">
+    <value>แสดงปุ่มตัวหนา</value>
+  </data>
+  <data name="Customize_Italic.Text" xml:space="preserve">
+    <value>แสดงปุ่มตัวเอียง</value>
+  </data>
+  <data name="Customize_Underline.Text" xml:space="preserve">
+    <value>แสดงปุ่มขีดเส้นใต้</value>
   </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -132,21 +132,6 @@
   <data name="SettingsPivot.Title" xml:space="preserve">
     <value>การตั้งค่า</value>
   </data>
-  <data name="SettingsTab1.Header" xml:space="preserve">
-    <value>ทั่วไป</value>
-  </data>
-  <data name="SettingsTab2.Header" xml:space="preserve">
-    <value>ธีม</value>
-  </data>
-  <data name="SettingsTab3.Header" xml:space="preserve">
-    <value>แบบอักษร</value>
-  </data>
-  <data name="SettingsTab4.Header" xml:space="preserve">
-    <value>แถบเครื่องมือ</value>
-  </data>
-  <data name="SettingsTab5.Header" xml:space="preserve">
-    <value>เกี่ยวกับ</value>
-  </data>
   <data name="ShowAlignCenter.OffContent" xml:space="preserve">
     <value>ซ่อนปุ่มจัดกลาง</value>
   </data>
@@ -777,5 +762,8 @@
   </data>
   <data name="Theme.Text" xml:space="preserve">
     <value>ธีม</value>
+  </data>
+  <data name="Font.Text" xml:space="preserve">
+    <value>แบบอักษร</value>
   </data>
 </root>


### PR DESCRIPTION
Also:
- Add "Theme.Text" for Theme setting page title
- Add "Font.Text" for Font setting page title
- Fix "App needs to restart" when changing language; not show after changing the language.
- Remove the previous version of setting page resource text from Resource.resw (SettingTabx.Header)
- Recycle "Theme" and "Font" for all language (No need to translate them again)
- Remove "Global button corner radius" and "Global dialog corner radius" setting
- Remove unused converters
- Fix "Show bold", "Show italic", and "Show underline" not point to a correct place on text resource